### PR TITLE
bug fix: profile name that is prefix of another profile name no longer errors out

### DIFF
--- a/awsume
+++ b/awsume
@@ -14,7 +14,7 @@ else
   then
 
   read token key id <<< $(
-   cat ~/.aws/cli/cache/${1}*.json | python -c '
+   cat ~/.aws/cli/cache/${1}--arn*.json | python -c '
 import json, sys
 creds = json.load(sys.stdin)["Credentials"]
 print(" ".join(creds[_] for _ in ("SessionToken","SecretAccessKey","AccessKeyId")))

--- a/awsume.bat
+++ b/awsume.bat
@@ -10,7 +10,7 @@ CALL aws s3 ls --profile %1 > nul
 
 IF ERRORLEVEL 1 GOTO end
 
-FOR /F %%M in ('DIR %userprofile%\.aws\cli\cache\%1*.json /B /S') DO (
+FOR /F %%M in ('DIR %userprofile%\.aws\cli\cache\%1--arn*.json /B /S') DO (
   FOR /F tokens^=16^,20^,28^ delims^=^" %%G IN (%%M) DO (
     IF "%2"=="show" (
       ECHO.


### PR DESCRIPTION
When you have 2 profile names, e.g.: "trek10" and "trek10-something", and you have already awsume-d "trek10-something", the script errors out when looking through the `~/.aws/cli/cache` directory upon awsume-ing "trek10" because it would find 2 files matching the pattern `trek10*.json`.