### PR TITLE
Replace old AWSume for Bash with new AWSume for Bash

### DIFF
--- a/awsume
+++ b/awsume
@@ -2,188 +2,137 @@
 #Author: Michael Barney, Trek10 Intern
 #Date: May 22, 2017
 #AWSume - a bash script to assume an AWS IAM role from the command-line
-#global variables
 
-PROFILE_NAME=""
-SOURCE_PROFILE=""
-ROLE_ARN=""
-MFA_ARN=""
-DEFAULT=false
-REFRESH=false
-SHOW=false
+AWSUME_PROFILE_NAME=""
+AWSUME_SOURCE_PROFILE=""
+AWSUME_ROLE_ARN=""
+AWSUME_MFA_ARN=""
+AWSUME_IS_USER=false
+
+#command-line options
+AWSUME_DEFAULT=false
+AWSUME_REFRESH=false
+AWSUME_SHOW=false
 
 #directory variables
-CACHE=~/.aws/cli/cache/
+AWSUME_CACHE=~/.aws/cli/cache/
 
 #Session Variables
-SessionText=""
-SessionSecretAccessKey=""
-SessionAccessKey=""
-SessionToken=""
-SessionExpiration=""
-
-#Remove the environment variables associated with the AWS CLI,
-#ensuring all environment variables will be valid
-Remove-AwsEnvs()
-{
-    unset AWS_SECRET_ACCESS_KEY
-    unset AWS_SESSION_TOKEN
-    unset AWS_SECURITY_TOKEN
-    unset AWS_ACCESS_KEY_ID
-    unset AWS_REGION
-    unset AWS_DEFAULT_REGION
-}
-
-#echo how to use the script and exit
-Usage()
-{
-    echo "USAGE: $0 <options/ProfileName>"
-    false
-}
-
-#parse through parameters and handle them
-Handle-Parameters()
-{
-    for var in "$@"
-    do
-        if [[ "$var" == "-"* ]]; then #this parameter is a flag
-            if [[ "$var" == *"-d"* ]]; then DEFAULT=true
-            elif [[ "$var" == *"-r"* ]]; then REFRESH=true
-            elif [[ "$var" == *"-s"* ]]; then SHOW=true
-            else Usage
-            fi
-        fi
-    done
-}
+AWSUME_SessionText=""
+AWSUME_SessionRegion=""
 
 #Set the environment variables
-Set-AwsEnvs()
+AWSUME_Set-AwsEnvs()
 {
-    region="$(aws configure get region --profile $PROFILE_NAME)"
-    export AWS_SECRET_ACCESS_KEY="$SessionSecretAccessKey"
-    export AWS_SESSION_TOKEN="$SessionToken"
-    export AWS_SECURITY_TOKEN="$SessionToken"
-    export AWS_ACCESS_KEY_ID="$SessionAccessKey"
-    export AWS_REGION="$region"
-    export AWS_DEFAULT_REGION="$region"
-}
-
-#*****various getters for the misc data*****
-Get-ProfileName()
-{
-    if [ "$DEFAULT" = true ]; then #go with default profile
-        PROFILE_NAME="default"
-    else 
-        if [ -z "$1" ]; then #if no paramater passed
-            PROFILE_NAME="default"
-        else
-            PROFILE_NAME=$1
-        fi
-    fi
-    #trim whitespace
-    PROFILE_NAME="$(echo -e "$PROFILE_NAME" | tr -d '[:space:]')"
-}
-
-Get-SourceProfile()
-{
-    SOURCE_PROFILE=$(aws configure get source_profile --profile "$PROFILE_NAME")
-    if [ -z "$SOURCE_PROFILE" ]; then
-        SOURCE_PROFILE="$PROFILE_NAME"
-    fi
-}
-
-Get-RoleArn()
-{
-    ROLE_ARN="$(aws configure get role_arn --profile "$PROFILE_NAME")"
-}
-
-Get-MfaArn()
-{
-    MFA_ARN="$(aws configure get mfa_serial --profile "$PROFILE_NAME")"
-    
-    if [ $? -gt 1 ]; then
-        exit 1
-    fi
-}
-
-#Scan through the .json file and grab the required object data
-Parse-Credentials() #$1 = profile to read from
-{
-    SessionSecretAccessKey=$(echo $SessionText | jp Credentials.SecretAccessKey | tr -d '[\"]') 
-    SessionAccessKey=$(echo $SessionText | jp Credentials.AccessKeyId | tr -d '[\"]')
-    SessionExpiration=$(echo $SessionText | jp Credentials.Expiration | tr -d '[\"]')
-    SessionToken=$(echo $SessionText | jp Credentials.SessionToken | tr -d '[\"]')
+    AWSUME_SessionRegion="$(aws configure get region --profile $AWSUME_PROFILE_NAME)"
+    export AWS_SECRET_ACCESS_KEY="${AWSUME_SessionText[1]}"
+    export AWS_SESSION_TOKEN="${AWSUME_SessionText[2]}"
+    export AWS_SECURITY_TOKEN="${AWSUME_SessionText[2]}"
+    export AWS_ACCESS_KEY_ID="${AWSUME_SessionText[0]}"
+    export AWS_REGION="$AWSUME_SessionRegion"
+    export AWS_DEFAULT_REGION="$AWSUME_SessionRegion"
 }
 
 #pull a saved session and test its expiration
-Get-SavedSession() #$1 = profile to get
+AWSUME_Get-SavedSession() #$1 = profile to get
 {
-    SessionText=""
-    tempProfile=${CACHE}awsume-temp-$1.json
-    if [ -e $tempProfile ]; then
-        SessionText=$(cat $tempProfile)
-        Parse-Credentials $1
+    AWSUME_SessionText=""
+    AWSUME_tempProfile=${AWSUME_CACHE}awsume-temp-$1.json
+    if [ -e $AWSUME_tempProfile ]; then
+        AWSUME_SessionText=(`cat $AWSUME_tempProfile`)
+        AWSUME_Set-AwsEnvs
+        #check if credentials are valid
+        aws sts get-caller-identity --region us-east-1 > /dev/null 2> /dev/null 
+        
+        if [ "$?" -ne "0" ]; then
+            rm AWSUME_tempProfile
+        fi
     fi
 }
 
 #Verify MFA and set the session to the environment variables
-Set-Session() #$1=profile to set
+AWSUME_Set-Session() #$1=profile to set
 {
-    SessionText=""
-    if [ $REFRESH = false ]; then
-        Get-SavedSession $1
+    AWSUME_SessionText=""
+    if [ $AWSUME_REFRESH = false ]; then
+        AWSUME_Get-SavedSession $AWSUME_SOURCE_PROFILE
     fi
-    if [ -z "$SessionText" ]; then
-        read -p "Enter MFA code: " mfaToken
+    if [ -z "$AWSUME_SessionText" ]; then
+        read -p "Enter MFA code: " AWSUME_mfaToken
         
         #grab the session "object"
-        SessionText=$(aws sts get-session-token --region us-east-1 --serial-number $MFA_ARN --token-code $mfaToken --profile $1 --output json)
-        if [ "$?" -ne "0" ]; then #the get-session-token failed
-            false
-        fi
-
+        AWSUME_USER_ARN=$(aws sts get-caller-identity --region us-east-1 --query Arn --output text --profile $1)
+        AWSUME_MFA_ARN=${AWSUME_USER_ARN/user/mfa}
+        AWSUME_SessionText=(`aws sts get-session-token --duration-seconds 900 --region us-east-1 --serial-number $AWSUME_MFA_ARN --token-code $AWSUME_mfaToken --profile $1 --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' --output text`)
         #write session text to cache file
-        [ -d $CACHE ] || mkdir $CACHE #if directory doesn't exist, make it
-        tempProfile="awsume-temp-$1.json"
-        echo $SessionText > "${CACHE}${tempProfile}"
+        [ -d $AWSUME_CACHE ] || mkdir $AWSUME_CACHE #if directory doesn't exist, make it
+        AWSUME_tempProfile="awsume-temp-$1.json"
+        echo ${AWSUME_SessionText[@]} > "${AWSUME_CACHE}${AWSUME_tempProfile}"
 
-        Parse-Credentials $1
     fi
-    echo "$1 expires: $SessionExpiration"
-    Set-AwsEnvs
+    AWSUME_Set-AwsEnvs
+    echo "#Source Profile Credentials ($1) expire: ${AWSUME_SessionText[3]}"
 }
 
 #Set your session first, then assume the role
-Set-AssumeRole()
+AWSUME_Set-AssumeRole()
 {
-    Set-Session $SOURCE_PROFILE
-
-    SessionText=$(aws sts assume-role --role-arn $ROLE_ARN --role-session-name "$PROFILE_NAME-$(date +%s)" --output json)
-
-    Parse-Credentials $PROFILE_NAME
-    echo "$PROFILE_NAME expires: $SessionExpiration"
-    Set-AwsEnvs
+    AWSUME_Set-Session $AWSUME_SOURCE_PROFILE
+    AWSUME_SessionText=(`aws sts assume-role --role-arn $AWSUME_ROLE_ARN --role-session-name "$AWSUME_PROFILE_NAME-$(date +%s)" --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' --output text`)
+    AWSUME_Set-AwsEnvs
+    echo "#Role Credentials ($AWSUME_PROFILE_NAME) expire: ${AWSUME_SessionText[3]}"
 }
 
-#main body of the script
-Remove-AwsEnvs
-Handle-Parameters $@
-Get-ProfileName $@
-Get-SourceProfile
-Get-RoleArn
-Get-MfaArn
+#Remove the environment variables associated with the AWS CLI,
+#ensuring all environment variables will be valid
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN
+unset AWS_SECURITY_TOKEN
+unset AWS_ACCESS_KEY_ID
+unset AWS_REGION
+unset AWS_DEFAULT_REGION
 
-if [ ! -z "$SOURCE_PROFILE" ] && [ ! -z "$ROLE_ARN" ]; then
-    Set-AssumeRole
-else
-    Set-Session $PROFILE_NAME
+#parse through parameters and handle them
+for AWSUME_var in "$@"
+do
+    if [[ "$AWSUME_var" == "-"* ]]; then #this parameter is a flag
+        if [[ "$AWSUME_var" == *"-d"* ]]; then AWSUME_DEFAULT=true
+        elif [[ "$AWSUME_var" == *"-r"* ]]; then AWSUME_REFRESH=true
+        elif [[ "$AWSUME_var" == *"-s"* ]]; then AWSUME_SHOW=true
+        else 
+            echo "USAGE: $0 <ProfileName> <options>"
+            return 1
+        fi
+    fi
+done
+
+#get the profile name
+if [ "$AWSUME_DEFAULT" = true ] || [ -z "$1" ]; then #go with default profile
+    AWSUME_PROFILE_NAME="default"
+else 
+    AWSUME_PROFILE_NAME=$1
+fi
+AWSUME_PROFILE_NAME="$(echo -e "$AWSUME_PROFILE_NAME" | tr -d '[:space:]')" #trim whitespace
+
+#get the source profile
+AWSUME_SOURCE_PROFILE=$(aws configure get source_profile --profile "$AWSUME_PROFILE_NAME")
+if [ -z "$AWSUME_SOURCE_PROFILE" ]; then
+    AWSUME_IS_USER=true
+    AWSUME_SOURCE_PROFILE="$AWSUME_PROFILE_NAME"
 fi
 
-if [ $SHOW = true ]; then
-    echo export AWS_SECRET_ACCESS_KEY=$sSessionSecretAccessKey
-    echo export AWS_SESSION_TOKEN=$SessionToken
-    echo export AWS_SECURITY_TOKEN=$SessionToken
-    echo export AWS_ACCESS_KEY_ID=$SessionAccessKey
-    echo export AWS_REGION=$(aws configure get region --profile $PROFILE_NAME)
-    echo export AWS_DEFAULT_REGION=$(aws configure get region --profile $PROFILE_NAME)
+if [ $AWSUME_IS_USER = true ]; then
+    AWSUME_Set-Session $AWSUME_PROFILE_NAME
+else
+    AWSUME_ROLE_ARN="$(aws configure get role_arn --profile "$AWSUME_PROFILE_NAME")"
+    AWSUME_Set-AssumeRole
+fi
+
+if [ $AWSUME_SHOW = true ]; then
+    echo export AWS_SECRET_ACCESS_KEY="${AWSUME_SessionText[1]}"
+    echo export AWS_SESSION_TOKEN="${AWSUME_SessionText[2]}"
+    echo export AWS_SECURITY_TOKEN="${AWSUME_SessionText[2]}"
+    echo export AWS_ACCESS_KEY_ID="${AWSUME_SessionText[0]}"
+    echo export AWS_REGION="$AWSUME_SessionRegion"
+    echo export AWS_DEFAULT_REGION="$AWSUME_SessionRegion"
 fi

--- a/awsume
+++ b/awsume
@@ -46,6 +46,7 @@ AWSUME_Get-SavedSession() #$1 = profile to get
         
         if [ "$?" -ne "0" ]; then
             rm $AWSUME_tempProfile
+	    AWSUME_SessionText=""
         fi
     fi
 }

--- a/awsume
+++ b/awsume
@@ -115,6 +115,9 @@ if [ -z "$AWSUME_SessionText" ]; then
         --profile $AWSUME_SOURCE_PROFILE \
         --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' \
         --output text`)
+    if [ "$?" -ne "0" ]; then
+        return 1
+    fi
 
     #write session text to cache file
     [ -d $AWSUME_CACHE ] || mkdir $AWSUME_CACHE #if directory doesn't exist, make it
@@ -123,7 +126,8 @@ if [ -z "$AWSUME_SessionText" ]; then
 
 fi
 AWSUME_Set-AwsEnvs
-echo "#Source Profile Credentials ($AWSUME_SOURCE_PROFILE) expire: ${AWSUME_SessionText[3]}"
+[ ! -z ${AWSUME_SessionText[3]} ] && \
+    echo "#Source Profile Credentials ($AWSUME_SOURCE_PROFILE) expire: ${AWSUME_SessionText[3]}"
 
 #now assume the role
 if [ $AWSUME_IS_USER != true ]; then
@@ -133,8 +137,14 @@ if [ $AWSUME_IS_USER != true ]; then
         --role-session-name "$AWSUME_PROFILE_NAME-$(date +%s)" \
         --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' \
         --output text`)
+    if [ "$?" -ne "0" ]; then
+        return 1
+    fi
+
     AWSUME_Set-AwsEnvs
-    echo "#Role Credentials ($AWSUME_PROFILE_NAME) expire: ${AWSUME_SessionText[3]}"
+    [ ! -z ${AWSUME_SessionText[3]} ] && \
+        [ ! -z ${AWSUME_SessionText[3]} ] && \
+            echo "#Role Credentials ($AWSUME_PROFILE_NAME) expire: ${AWSUME_SessionText[3]}"
 fi
 
 if [ $AWSUME_SHOW = true ]; then

--- a/awsume
+++ b/awsume
@@ -26,18 +26,19 @@ SessionExpiration=""
 #ensuring all environment variables will be valid
 Remove-AwsEnvs()
 {
-    export AWS_SECRET_ACCESS_KEY=""
-    export AWS_SESSION_TOKEN=""
-    export AWS_ACCESS_KEY_ID=""
-    export AWS_REGION=""
-    export AWS_DEFAULT_REGION=""
+    unset AWS_SECRET_ACCESS_KEY
+    unset AWS_SESSION_TOKEN
+    unset AWS_SECURITY_TOKEN
+    unset AWS_ACCESS_KEY_ID
+    unset AWS_REGION
+    unset AWS_DEFAULT_REGION
 }
 
 #echo how to use the script and exit
 Usage()
 {
     echo "USAGE: $0 <options/ProfileName>"
-    exit 1
+    false
 }
 
 #parse through parameters and handle them
@@ -74,10 +75,7 @@ Get-ProfileName()
         PROFILE_NAME="default"
     else 
         if [ -z "$1" ]; then #if no paramater passed
-            echo "Enter the profile name [default]: "
-            read PROFILE_NAME
-            #check if profile name is still empty
-            [ -z "$PROFILE_NAME" ] && echo "Use -d to set default" && PROFILE_NAME="default"
+            PROFILE_NAME="default"
         else
             PROFILE_NAME=$1
         fi
@@ -111,9 +109,10 @@ Get-MfaArn()
 #Scan through the .json file and grab the required object data
 Parse-Credentials() #$1 = profile to read from
 {
-    read SessionSecretAccessKey SessionAccessKey SessionToken SessionExpiration <<< $(cat ${CACHE}awsume-temp-$1.json | python -c 'import json, sys
-creds = json.load(sys.stdin)["Credentials"]
-print(" ".join(creds[_] for _ in ("SecretAccessKey","AccessKeyId","SessionToken","Expiration")))')
+    SessionSecretAccessKey=$(echo $SessionText | jp Credentials.SecretAccessKey | tr -d '[\"]') 
+    SessionAccessKey=$(echo $SessionText | jp Credentials.AccessKeyId | tr -d '[\"]')
+    SessionExpiration=$(echo $SessionText | jp Credentials.Expiration | tr -d '[\"]')
+    SessionToken=$(echo $SessionText | jp Credentials.SessionToken | tr -d '[\"]')
 }
 
 #pull a saved session and test its expiration
@@ -124,23 +123,6 @@ Get-SavedSession() #$1 = profile to get
     if [ -e $tempProfile ]; then
         SessionText=$(cat $tempProfile)
         Parse-Credentials $1
-
-        #calculate timeLeft in minutes
-        t1=$(date -d $SessionExpiration +%s) #expiration date in epoch
-        t2=$(date +%s) #current time in epoch
-        ts="$(($t1 - $t2))" #total seconds
-        tm="$(($ts / 60))" #total minutes        
-        th="$(($tm / 60))" #total hours
-        
-        if [ $tm -le 0 ]; then #session expired
-            echo "Expired Session"
-            SessionText=""
-        elif [ $tm -lt 10 ]; then
-            read -p "Session about to expire ($tm minutes), refresh token? [Y]: " Option
-            [ "$Option" = "Y" ] && SessionText="" #refresh token
-        else
-            [ $tm -gt 60 ] && echo "Session Expiring in $th hours" || echo "Session Expiring in $tm minutes"
-        fi
     fi
 }
 
@@ -153,9 +135,13 @@ Set-Session() #$1=profile to set
     fi
     if [ -z "$SessionText" ]; then
         read -p "Enter MFA code: " mfaToken
-        #grab the session "object"
-        SessionText=$(aws sts get-session-token --serial-number $MFA_ARN --token-code $mfaToken --profile $1 --output json)
         
+        #grab the session "object"
+        SessionText=$(aws sts get-session-token --region us-east-1 --serial-number $MFA_ARN --token-code $mfaToken --profile $1 --output json)
+        if [ "$?" -ne "0" ]; then #the get-session-token failed
+            false
+        fi
+
         #write session text to cache file
         [ -d $CACHE ] || mkdir $CACHE #if directory doesn't exist, make it
         tempProfile="awsume-temp-$1.json"
@@ -163,6 +149,7 @@ Set-Session() #$1=profile to set
 
         Parse-Credentials $1
     fi
+    echo "$1 expires: $SessionExpiration"
     Set-AwsEnvs
 }
 
@@ -172,15 +159,9 @@ Set-AssumeRole()
     Set-Session $SOURCE_PROFILE
 
     SessionText=$(aws sts assume-role --role-arn $ROLE_ARN --role-session-name "$PROFILE_NAME-$(date +%s)" --output json)
-    
-
-    #*****WE don't want to save these role credentials**************
-    #write session text to cache file
-    [ -d $CACHE ] || mkdir $CACHE #if directory doesn't exist, make it
-    tempProfile="awsume-temp-$PROFILE_NAME.json"
-    echo $SessionText > "${CACHE}${tempProfile}"
 
     Parse-Credentials $PROFILE_NAME
+    echo "$PROFILE_NAME expires: $SessionExpiration"
     Set-AwsEnvs
 }
 
@@ -191,7 +172,6 @@ Get-ProfileName $@
 Get-SourceProfile
 Get-RoleArn
 Get-MfaArn
-Set-AwsEnvs
 
 if [ ! -z "$SOURCE_PROFILE" ] && [ ! -z "$ROLE_ARN" ]; then
     Set-AssumeRole

--- a/awsume
+++ b/awsume
@@ -46,7 +46,7 @@ AWSUME_Get-SavedSession() #$1 = profile to get
         
         if [ "$?" -ne "0" ]; then
             rm $AWSUME_tempProfile
-	    AWSUME_SessionText=""
+	        AWSUME_SessionText=""
         fi
     fi
 }

--- a/awsume
+++ b/awsume
@@ -45,7 +45,7 @@ AWSUME_Get-SavedSession() #$1 = profile to get
         aws sts get-caller-identity --region us-east-1 > /dev/null 2> /dev/null 
         
         if [ "$?" -ne "0" ]; then
-            rm AWSUME_tempProfile
+            rm $AWSUME_tempProfile
         fi
     fi
 }
@@ -63,7 +63,7 @@ AWSUME_Set-Session() #$1=profile to set
         #grab the session "object"
         AWSUME_USER_ARN=$(aws sts get-caller-identity --region us-east-1 --query Arn --output text --profile $1)
         AWSUME_MFA_ARN=${AWSUME_USER_ARN/user/mfa}
-        AWSUME_SessionText=(`aws sts get-session-token --duration-seconds 900 --region us-east-1 --serial-number $AWSUME_MFA_ARN --token-code $AWSUME_mfaToken --profile $1 --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' --output text`)
+        AWSUME_SessionText=(`aws sts get-session-token --region us-east-1 --serial-number $AWSUME_MFA_ARN --token-code $AWSUME_mfaToken --profile $1 --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' --output text`)
         #write session text to cache file
         [ -d $AWSUME_CACHE ] || mkdir $AWSUME_CACHE #if directory doesn't exist, make it
         AWSUME_tempProfile="awsume-temp-$1.json"

--- a/awsume
+++ b/awsume
@@ -1,57 +1,204 @@
 #!/bin/bash
+#Author: Michael Barney, Trek10 Intern
+#Date: May 22, 2017
+#AWSume - a bash script to assume an AWS IAM role from the command-line
 
-if [[ -z "$1" ]];
-then 
-  echo Missing profile name
-  exit 1
-else
-  if [[ "$2" == "refresh" ]];
-  then
-    rm ~/.aws/cli/cache/$1*
-  fi
-  
-  if aws sts get-caller-identity --profile $1 >/dev/null
-  then
+#global variables
+PROFILE_NAME=""
+SOURCE_PROFILE=""
+ROLE_ARN=""
+MFA_ARN=""
+DEFAULT=false
+REFRESH=false
+SHOW=false
 
-  read token key id <<< $(
-   cat ~/.aws/cli/cache/${1}--arn*.json | python -c '
-import json, sys
-creds = json.load(sys.stdin)["Credentials"]
-print(" ".join(creds[_] for _ in ("SessionToken","SecretAccessKey","AccessKeyId")))
-')
+#directory variables
+CACHE=~/.aws/cli/cache/
 
-    region=$(aws configure get region --profile $1)
+#Session Variables
+SessionText=""
+SessionSecretAccessKey=""
+SessionAccessKey=""
+SessionToken=""
+SessionExpiration=""
+
+#Remove the environment variables associated with the AWS CLI,
+#ensuring all environment variables will be valid
+Remove-AwsEnvs()
+{
+    export AWS_SECRET_ACCESS_KEY=""
+    export AWS_SESSION_TOKEN=""
+    export AWS_ACCESS_KEY_ID=""
+    export AWS_REGION=""
+    export AWS_DEFAULT_REGION=""
+}
+
+#echo how to use the script and exit
+Usage()
+{
+    echo "USAGE: $0 <options/ProfileName>"
+    exit 1
+}
+
+#parse through parameters and handle them
+Handle-Parameters()
+{
+    for var in "$@"
+    do
+        if [[ "$var" == "-"* ]]; then #this parameter is a flag
+            if [[ "$var" == *"-d"* ]]; then DEFAULT=true
+            elif [[ "$var" == *"-r"* ]]; then REFRESH=true
+            elif [[ "$var" == *"-s"* ]]; then SHOW=true
+            else Usage
+            fi
+        fi
+    done
+}
+
+#Set the environment variables
+Set-AwsEnvs()
+{
+    export AWS_SECRET_ACCESS_KEY="$SessionSecretAccessKey"
+    export AWS_SESSION_TOKEN="$SessionToken"
+    export AWS_ACCESS_KEY_ID="$SessionAccessKey"
+    export AWS_REGION="$(aws configure get region --profile $PROFILE_NAME)"
+    export AWS_DEFAULT_REGION="$(aws configure get region --profile $PROFILE_NAME)"
+}
+
+#*****various getters for the misc data*****
+Get-ProfileName()
+{
+    if [ "$DEFAULT" = true ]; then #go with default profile
+        PROFILE_NAME="default"
+    else 
+        if [ -z "$1" ]; then #if no paramater passed
+            echo "Enter the profile name [default]: "
+            read PROFILE_NAME
+            #check if profile name is still empty
+            [ -z "$PROFILE_NAME" ] && echo "Use -d to set default" && PROFILE_NAME="default"
+        else
+            PROFILE_NAME=$1
+        fi
+    fi
+    #trim whitespace
+    PROFILE_NAME="$(echo -e "$PROFILE_NAME" | tr -d '[:space:]')"
+}
+
+Get-SourceProfile()
+{
+    SOURCE_PROFILE=$(aws configure get source_profile --profile "$PROFILE_NAME")
+    if [ -z "$SOURCE_PROFILE" ]; then
+        SOURCE_PROFILE="$PROFILE_NAME"
+    fi
+}
+
+Get-RoleArn()
+{
+    ROLE_ARN="$(aws configure get role_arn --profile "$PROFILE_NAME")"
+}
+
+Get-MfaArn()
+{
+    MFA_ARN="$(aws configure get mfa_serial --profile "$PROFILE_NAME")"
     
-    if [[ "$2" == "show" ]];
-    then
-      echo "export AWS_SESSION_TOKEN=$token"
-      echo "export AWS_SECURITY_TOKEN=$token"
-      echo "export AWS_SECRET_ACCESS_KEY=$key"
-      echo "export AWS_ACCESS_KEY_ID=$id"
-      if [[ -z "$region" ]];
-      then
-        echo "# No region set"
-      else
-        echo "export AWS_REGION=$region"
-        echo "export AWS_DEFAULT_REGION=$region"
-      fi
+    if [ $? -gt 1 ]; then
+        exit 1
     fi
+}
 
-    if [[ "$TERM_PROGRAM" == "iTerm.app" ]];
-    then
-      echo -ne "\033]1;AWS ROLE: $1\007"
+#Scan through the .json file and grab the required object data
+Parse-Credentials()
+{
+    read SessionSecretAccessKey SessionAccessKey SessionToken SessionExpiration <<< $(cat ${CACHE}awsume-temp-${SOURCE_PROFILE}.json | python -c 'import json, sys
+creds = json.load(sys.stdin)["Credentials"]
+print(" ".join(creds[_] for _ in ("SecretAccessKey","AccessKeyId","SessionToken","Expiration")))')
+}
+
+#pull a saved session and test its expiration
+Get-SavedSession() #$1 = profile to get
+{
+    SessionText=""
+    tempProfile=${CACHE}awsume-temp-$1.json
+    if [ -e $tempProfile ]; then
+        SessionText=$(cat $tempProfile)
+        Parse-Credentials
+
+        #calculate timeLeft in minutes
+        t1=$(date -d $SessionExpiration +%s) #expiration date in epoch
+        t2=$(date +%s) #current time in epoch
+        ts="$(($t1 - $t2))" #total seconds
+        tm="$(($ts / 60))" #total minutes        
+        th="$(($tm / 60))" #total hours
+
+        [ $tm -gt 60 ] && echo "Session Expiring in $th hours, $tm minutes" || echo "Session Expiring in $tm minutes"
+        
+        if [ $tm -le 0 ]; then #session expired
+            echo "Expired Session"
+            SessionText=""
+        elif [ $tm -lt 10 ]; then
+            read -p "Session about to expire, refresh token? [Y]: " Option
+            [ "$Option" = "Y" ] && SessionText="" #refresh token
+        fi
     fi
-    export AWS_SECURITY_TOKEN=$token
-    export AWS_SESSION_TOKEN=$token
-    export AWS_SECRET_ACCESS_KEY=$key
-    export AWS_ACCESS_KEY_ID=$id
-    if [[ -z "$region" ]];
-    then
-      unset AWS_REGION
-      unset AWS_DEFAULT_REGION
-    else
-      export AWS_REGION=$region
-      export AWS_DEFAULT_REGION=$region
+}
+
+#Verify MFA and set the session to the environment variables
+Set-Session() #$1=profile to set
+{
+    SessionText=""
+    if [ $REFRESH = false ]; then
+        Get-SavedSession $1
     fi
-  fi
+    if [ -z "$SessionText" ]; then
+        read -p "Enter MFA code: " mfaToken
+        #grab the session "object"
+        SessionText=$(aws sts get-session-token --serial-number $MFA_ARN --token-code $mfaToken --profile $1 --output json)
+        
+        #write session text to cache file
+        [ -d $CACHE ] || mkdir $CACHE #if directory doesn't exist, make it
+        tempProfile="awsume-temp-$1.json"
+        echo $SessionText > "${CACHE}${tempProfile}"
+
+        Parse-Credentials
+    fi
+    Set-AwsEnvs
+}
+
+#Set your session first, then assume the role
+Set-AssumeRole()
+{
+    Set-Session $SOURCE_PROFILE
+
+    SessionText=$(aws sts assume-role --role-arn $ROLE_ARN --role-session-name awsume-temp-${PROFILE_NAME} --output json)
+    
+    #write session text to cache file
+    [ -d $CACHE ] || mkdir $CACHE #if directory doesn't exist, make it
+    tempProfile="awsume-temp-$PROFILE_NAME.json"
+    echo $SessionText > "${CACHE}${tempProfile}"
+
+    Parse-Credentials
+    Set-AwsEnvs
+}
+
+#main body of the script
+Remove-AwsEnvs
+Handle-Parameters $@
+Get-ProfileName $@
+Get-SourceProfile
+Get-RoleArn
+Get-MfaArn
+Set-AwsEnvs
+
+if [ ! -z "$SOURCE_PROFILE" ] && [ ! -z "$ROLE_ARN" ]; then
+    Set-AssumeRole
+else
+    Set-Session $PROFILE_NAME
+fi
+
+if [ $SHOW = true ]; then
+    echo export AWS_SECRET_ACCESS_KEY=$sSessionSecretAccessKey
+    echo export AWS_SESSION_TOKEN=$SessionToken
+    echo export AWS_ACCESS_KEY_ID=$SessionAccessKey
+    echo export AWS_REGION=$(aws configure get region --profile $PROFILE_NAME)
+    echo export AWS_DEFAULT_REGION=$(aws configure get region --profile $PROFILE_NAME)
 fi

--- a/awsume
+++ b/awsume
@@ -33,72 +33,6 @@ AWSUME_Set-AwsEnvs()
     export AWS_DEFAULT_REGION="$AWSUME_SessionRegion"
 }
 
-#pull a saved session and test its expiration
-AWSUME_Get-SavedSession() #$1 = profile to get
-{
-    AWSUME_SessionText=""
-    AWSUME_tempProfile=${AWSUME_CACHE}awsume-temp-$1.json
-    if [ -e $AWSUME_tempProfile ]; then
-        AWSUME_SessionText=(`cat $AWSUME_tempProfile`)
-        AWSUME_Set-AwsEnvs
-        #check if credentials are valid
-        aws sts get-caller-identity --region us-east-1 > /dev/null 2> /dev/null 
-        
-        if [ "$?" -ne "0" ]; then
-            rm $AWSUME_tempProfile
-	    AWSUME_SessionText=""
-        fi
-    fi
-}
-
-#Verify MFA and set the session to the environment variables
-AWSUME_Set-Session() #$1=profile to set
-{
-    AWSUME_SessionText=""
-    if [ $AWSUME_REFRESH = false ]; then
-        AWSUME_Get-SavedSession $AWSUME_SOURCE_PROFILE
-    fi
-    if [ -z "$AWSUME_SessionText" ]; then
-        read -p "Enter MFA code: " AWSUME_mfaToken
-        
-        #grab the session "object"
-        AWSUME_USER_ARN=$(aws sts get-caller-identity \
-        --region us-east-1 \
-        --query Arn \
-        --output text \
-        --profile $1)
-        
-        AWSUME_MFA_ARN=${AWSUME_USER_ARN/user/mfa}
-        AWSUME_SessionText=(`aws sts get-session-token \
-        --region us-east-1 \
-        --serial-number $AWSUME_MFA_ARN \
-        --token-code $AWSUME_mfaToken \
-        --profile $1 \
-        --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' \
-        --output text`)
-        #write session text to cache file
-        [ -d $AWSUME_CACHE ] || mkdir $AWSUME_CACHE #if directory doesn't exist, make it
-        AWSUME_tempProfile="awsume-temp-$1.json"
-        echo ${AWSUME_SessionText[@]} > "${AWSUME_CACHE}${AWSUME_tempProfile}"
-
-    fi
-    AWSUME_Set-AwsEnvs
-    echo "#Source Profile Credentials ($1) expire: ${AWSUME_SessionText[3]}"
-}
-
-#Set your session first, then assume the role
-AWSUME_Set-AssumeRole()
-{
-    AWSUME_Set-Session $AWSUME_SOURCE_PROFILE
-    AWSUME_SessionText=(`aws sts assume-role \
-    --role-arn $AWSUME_ROLE_ARN \
-    --role-session-name "$AWSUME_PROFILE_NAME-$(date +%s)" \
-    --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' \
-    --output text`)
-    AWSUME_Set-AwsEnvs
-    echo "#Role Credentials ($AWSUME_PROFILE_NAME) expire: ${AWSUME_SessionText[3]}"
-}
-
 #Remove the environment variables associated with the AWS CLI,
 #ensuring all environment variables will be valid
 unset AWS_SECRET_ACCESS_KEY
@@ -137,11 +71,70 @@ if [ -z "$AWSUME_SOURCE_PROFILE" ]; then
     AWSUME_SOURCE_PROFILE="$AWSUME_PROFILE_NAME"
 fi
 
-if [ $AWSUME_IS_USER = true ]; then
-    AWSUME_Set-Session $AWSUME_PROFILE_NAME
-else
+#clear session attributes
+AWSUME_SessionText=""
+
+#if we have to grab a cached profile
+if [ $AWSUME_REFRESH = false ]; then
+    AWSUME_SessionText=""
+    AWSUME_tempProfile=${AWSUME_CACHE}awsume-temp-$AWSUME_SOURCE_PROFILE.json
+    if [ -e $AWSUME_tempProfile ]; then
+        AWSUME_SessionText=(`cat $AWSUME_tempProfile`)
+        AWSUME_Set-AwsEnvs
+        #check if credentials are valid
+        aws sts get-caller-identity --region us-east-1 > /dev/null 2> /dev/null 
+        
+        if [ "$?" -ne "0" ]; then
+            rm $AWSUME_tempProfile
+	        AWSUME_SessionText=""
+        fi
+    fi
+fi
+
+if [ -z "$AWSUME_SessionText" ]; then
+    read -p "#Enter MFA code: " AWSUME_mfaToken
+
+    #validate the mfa token
+    if [[ ! $AWSUME_mfaToken =~ ^[0-9]{6}$ ]]; then
+        echo "#Invalid MFA token"
+        return 1
+    fi
+
+    #grab the session "object"
+    AWSUME_USER_ARN=$(aws sts get-caller-identity \
+        --region us-east-1 \
+        --query Arn \
+        --output text \
+        --profile $AWSUME_SOURCE_PROFILE)
+    
+    AWSUME_MFA_ARN=${AWSUME_USER_ARN/user/mfa}
+    AWSUME_SessionText=(`aws sts get-session-token \
+        --region us-east-1 \
+        --serial-number $AWSUME_MFA_ARN \
+        --token-code $AWSUME_mfaToken \
+        --profile $AWSUME_SOURCE_PROFILE \
+        --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' \
+        --output text`)
+
+    #write session text to cache file
+    [ -d $AWSUME_CACHE ] || mkdir $AWSUME_CACHE #if directory doesn't exist, make it
+    AWSUME_tempProfile="awsume-temp-$AWSUME_SOURCE_PROFILE.json"
+    echo ${AWSUME_SessionText[@]} > "${AWSUME_CACHE}${AWSUME_tempProfile}"
+
+fi
+AWSUME_Set-AwsEnvs
+echo "#Source Profile Credentials ($AWSUME_SOURCE_PROFILE) expire: ${AWSUME_SessionText[3]}"
+
+#now assume the role
+if [ $AWSUME_IS_USER != true ]; then
     AWSUME_ROLE_ARN="$(aws configure get role_arn --profile "$AWSUME_PROFILE_NAME")"
-    AWSUME_Set-AssumeRole
+    AWSUME_SessionText=(`aws sts assume-role \
+        --role-arn $AWSUME_ROLE_ARN \
+        --role-session-name "$AWSUME_PROFILE_NAME-$(date +%s)" \
+        --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' \
+        --output text`)
+    AWSUME_Set-AwsEnvs
+    echo "#Role Credentials ($AWSUME_PROFILE_NAME) expire: ${AWSUME_SessionText[3]}"
 fi
 
 if [ $AWSUME_SHOW = true ]; then

--- a/awsume
+++ b/awsume
@@ -2,8 +2,8 @@
 #Author: Michael Barney, Trek10 Intern
 #Date: May 22, 2017
 #AWSume - a bash script to assume an AWS IAM role from the command-line
-
 #global variables
+
 PROFILE_NAME=""
 SOURCE_PROFILE=""
 ROLE_ARN=""
@@ -58,11 +58,13 @@ Handle-Parameters()
 #Set the environment variables
 Set-AwsEnvs()
 {
+    region="$(aws configure get region --profile $PROFILE_NAME)"
     export AWS_SECRET_ACCESS_KEY="$SessionSecretAccessKey"
     export AWS_SESSION_TOKEN="$SessionToken"
+    export AWS_SECURITY_TOKEN="$SessionToken"
     export AWS_ACCESS_KEY_ID="$SessionAccessKey"
-    export AWS_REGION="$(aws configure get region --profile $PROFILE_NAME)"
-    export AWS_DEFAULT_REGION="$(aws configure get region --profile $PROFILE_NAME)"
+    export AWS_REGION="$region"
+    export AWS_DEFAULT_REGION="$region"
 }
 
 #*****various getters for the misc data*****
@@ -107,9 +109,9 @@ Get-MfaArn()
 }
 
 #Scan through the .json file and grab the required object data
-Parse-Credentials()
+Parse-Credentials() #$1 = profile to read from
 {
-    read SessionSecretAccessKey SessionAccessKey SessionToken SessionExpiration <<< $(cat ${CACHE}awsume-temp-${SOURCE_PROFILE}.json | python -c 'import json, sys
+    read SessionSecretAccessKey SessionAccessKey SessionToken SessionExpiration <<< $(cat ${CACHE}awsume-temp-$1.json | python -c 'import json, sys
 creds = json.load(sys.stdin)["Credentials"]
 print(" ".join(creds[_] for _ in ("SecretAccessKey","AccessKeyId","SessionToken","Expiration")))')
 }
@@ -121,7 +123,7 @@ Get-SavedSession() #$1 = profile to get
     tempProfile=${CACHE}awsume-temp-$1.json
     if [ -e $tempProfile ]; then
         SessionText=$(cat $tempProfile)
-        Parse-Credentials
+        Parse-Credentials $1
 
         #calculate timeLeft in minutes
         t1=$(date -d $SessionExpiration +%s) #expiration date in epoch
@@ -129,15 +131,15 @@ Get-SavedSession() #$1 = profile to get
         ts="$(($t1 - $t2))" #total seconds
         tm="$(($ts / 60))" #total minutes        
         th="$(($tm / 60))" #total hours
-
-        [ $tm -gt 60 ] && echo "Session Expiring in $th hours, $tm minutes" || echo "Session Expiring in $tm minutes"
         
         if [ $tm -le 0 ]; then #session expired
             echo "Expired Session"
             SessionText=""
         elif [ $tm -lt 10 ]; then
-            read -p "Session about to expire, refresh token? [Y]: " Option
+            read -p "Session about to expire ($tm minutes), refresh token? [Y]: " Option
             [ "$Option" = "Y" ] && SessionText="" #refresh token
+        else
+            [ $tm -gt 60 ] && echo "Session Expiring in $th hours" || echo "Session Expiring in $tm minutes"
         fi
     fi
 }
@@ -159,7 +161,7 @@ Set-Session() #$1=profile to set
         tempProfile="awsume-temp-$1.json"
         echo $SessionText > "${CACHE}${tempProfile}"
 
-        Parse-Credentials
+        Parse-Credentials $1
     fi
     Set-AwsEnvs
 }
@@ -169,14 +171,16 @@ Set-AssumeRole()
 {
     Set-Session $SOURCE_PROFILE
 
-    SessionText=$(aws sts assume-role --role-arn $ROLE_ARN --role-session-name awsume-temp-${PROFILE_NAME} --output json)
+    SessionText=$(aws sts assume-role --role-arn $ROLE_ARN --role-session-name "$PROFILE_NAME-$(date +%s)" --output json)
     
+
+    #*****WE don't want to save these role credentials**************
     #write session text to cache file
     [ -d $CACHE ] || mkdir $CACHE #if directory doesn't exist, make it
     tempProfile="awsume-temp-$PROFILE_NAME.json"
     echo $SessionText > "${CACHE}${tempProfile}"
 
-    Parse-Credentials
+    Parse-Credentials $PROFILE_NAME
     Set-AwsEnvs
 }
 
@@ -198,6 +202,7 @@ fi
 if [ $SHOW = true ]; then
     echo export AWS_SECRET_ACCESS_KEY=$sSessionSecretAccessKey
     echo export AWS_SESSION_TOKEN=$SessionToken
+    echo export AWS_SECURITY_TOKEN=$SessionToken
     echo export AWS_ACCESS_KEY_ID=$SessionAccessKey
     echo export AWS_REGION=$(aws configure get region --profile $PROFILE_NAME)
     echo export AWS_DEFAULT_REGION=$(aws configure get region --profile $PROFILE_NAME)

--- a/awsume
+++ b/awsume
@@ -46,7 +46,7 @@ AWSUME_Get-SavedSession() #$1 = profile to get
         
         if [ "$?" -ne "0" ]; then
             rm $AWSUME_tempProfile
-	        AWSUME_SessionText=""
+	    AWSUME_SessionText=""
         fi
     fi
 }
@@ -62,9 +62,20 @@ AWSUME_Set-Session() #$1=profile to set
         read -p "Enter MFA code: " AWSUME_mfaToken
         
         #grab the session "object"
-        AWSUME_USER_ARN=$(aws sts get-caller-identity --region us-east-1 --query Arn --output text --profile $1)
+        AWSUME_USER_ARN=$(aws sts get-caller-identity \
+        --region us-east-1 \
+        --query Arn \
+        --output text \
+        --profile $1)
+        
         AWSUME_MFA_ARN=${AWSUME_USER_ARN/user/mfa}
-        AWSUME_SessionText=(`aws sts get-session-token --region us-east-1 --serial-number $AWSUME_MFA_ARN --token-code $AWSUME_mfaToken --profile $1 --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' --output text`)
+        AWSUME_SessionText=(`aws sts get-session-token \
+        --region us-east-1 \
+        --serial-number $AWSUME_MFA_ARN \
+        --token-code $AWSUME_mfaToken \
+        --profile $1 \
+        --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' \
+        --output text`)
         #write session text to cache file
         [ -d $AWSUME_CACHE ] || mkdir $AWSUME_CACHE #if directory doesn't exist, make it
         AWSUME_tempProfile="awsume-temp-$1.json"
@@ -79,7 +90,11 @@ AWSUME_Set-Session() #$1=profile to set
 AWSUME_Set-AssumeRole()
 {
     AWSUME_Set-Session $AWSUME_SOURCE_PROFILE
-    AWSUME_SessionText=(`aws sts assume-role --role-arn $AWSUME_ROLE_ARN --role-session-name "$AWSUME_PROFILE_NAME-$(date +%s)" --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' --output text`)
+    AWSUME_SessionText=(`aws sts assume-role \
+    --role-arn $AWSUME_ROLE_ARN \
+    --role-session-name "$AWSUME_PROFILE_NAME-$(date +%s)" \
+    --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken,Credentials.Expiration]' \
+    --output text`)
     AWSUME_Set-AwsEnvs
     echo "#Role Credentials ($AWSUME_PROFILE_NAME) expire: ${AWSUME_SessionText[3]}"
 }

--- a/awsume.ps1
+++ b/awsume.ps1
@@ -1,113 +1,92 @@
-param (
+Param (
     [string]$profileName = "default",
     [switch]$d = $false,
-    [switch]$refresh = $false
+    [switch]$r = $false,
+    [switch]$s = $false
 )
-
-function Remove-AwsEnvs() {
-    $env:AWS_SECRET_ACCESS_KEY = ""
-    $env:AWS_SESSION_TOKEN = ""
-    $env:AWS_ACCESS_KEY_ID = ""
-    $env:AWS_REGION = ""
-    $env:AWS_DEFAULT_REGION = ""
-}
 
 function Get-SavedSession([string]$profileName) {
     $session = $null
     $tempProfile = "awsume-temp-$profileName"
     if (Test-Path "~\.aws\cli\cache\$tempProfile.json") {
         $session = Get-Content "~\.aws\cli\cache\$tempProfile.json" | ConvertFrom-Json
-        $timeLeft = New-TimeSpan -Start (Get-Date) -End (Get-Date $session.Credentials.Expiration)
-        if ($timeLeft.TotalMinutes -le 0) {
+        Set-Environment $profileName $session
+
+        aws sts get-caller-identity > $null
+        if ( -not $? ) {
+            #cache is invalid
+            rm "~\.aws\cli\cache\$tempProfile.json"
             $session = $null
-        } elseif ($timeLeft.TotalMinutes -lt 10) {
-            $x = [math]::Round($timeLeft.TotalMinutes)
-            $refreshToken = Read-Host "About $x minutes remain, refresh token? [Y/n]"
-            if ([string]::IsNullOrWhiteSpace($refreshToken) -or $refreshToken -like "Y") {
-                $session = $null
-            }
         }
     }
     return $session
 }
 
-function Get-ProfileName([string]$profileName) {
-    if ($d -eq $false -and $profileName -eq "default") {
-        $profileName = Read-Host -Prompt 'Enter the profile [default]'
-        if ([string]::IsNullOrWhiteSpace($profileName) -or $profileName -eq "default") {
-            $profileName = "default"
-            Write-Host "In the future, you can use the -d flag to skip entering default"
-        }
-    }
-    return $profileName
-}
-
-function Get-SourceProfile([string]$profileName) {
-    $sourceProfile = aws configure get source_profile --profile $profileName
-    if ([string]::IsNullOrWhiteSpace($sourceProfile)) {
-        $sourceProfile = $profileName
-    }
-    return $sourceProfile
-}
-
-function Get-RoleArn([string]$profileName) {
-    $roleArn = aws configure get role_arn --profile $profileName
-    return $roleArn
-}
-
-function Get-MfaArn([string]$profileName) {
-    $mfaArn = aws configure get mfa_serial --profile $profileName
-    if ($LASTEXITCODE -gt 1) {
-        exit # It can exist or not (0 or 1). That's ok but if it crashes, then we need to exit
-    }
-    return $mfaArn
-}
-
-function Set-Session([string]$profileName, [string]$mfaArn, [switch]$refresh) {
+function Set-Session([string]$profileName, [bool]$r) {
     $session = $null
-    if (-Not $refresh) {
+    if (-Not $r) {
         $session = Get-SavedSession $profileName
     }
     if (-Not $session) {
-        $secureMfaToken = Read-Host -AsSecureString "Enter MFA code"
-        $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureMfaToken)
-        $mfaToken = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+        $mfaToken = Read-Host -Prompt "Enter MFA code"
+        [string]$AWSUME_UserArn= aws sts get-caller-identity --region us-east-1 --query Arn --output text --profile $profileName
+        [string]$AWSUME_MfaArn=$AWSUME_UserArn -replace "user", "mfa"
+        $session = aws sts get-session-token --serial-number $AWSUME_MfaArn --token-code $mfaToken --profile $profileName --output json | ConvertFrom-Json
 
-        $session = aws sts get-session-token --serial-number $mfaArn --token-code $mfaToken --profile $profileName --output json | ConvertFrom-Json
+        #write the credentials to cache
+        if (-Not (Test-Path "~\.aws\cli\cache\")) {
+            mkdir "~\.aws\cli\cache\"
+        }
+        $tempProfile = "awsume-temp-$profileName"
+        ConvertTo-Json $session | Out-File -Force -FilePath "~\.aws\cli\cache\$tempProfile.json"
     }
     Set-Environment $profileName $session
+    Write-Host "#Source Profile Credentials ($profileName) expire:" $session.Credentials.Expiration
 }
 
 function Set-Environment([string]$profileName, $session) {
     $env:AWS_SECRET_ACCESS_KEY = $session.Credentials.SecretAccessKey
     $env:AWS_SESSION_TOKEN = $session.Credentials.SessionToken
+    $env:AWS_SECURITY_TOKEN = $session.Credentials.SessionToken
     $env:AWS_ACCESS_KEY_ID = $session.Credentials.AccessKeyId
     $env:AWS_REGION = aws configure get region --profile $profileName
-    $env:AWS_DEFAULT_REGION = aws configure get region --profile $profileName
-    
-    if (-Not (Test-Path "~\.aws\cli\cache\")) {
-        mkdir "~\.aws\cli\cache\"
-    }
-    $tempProfile = "awsume-temp-$profileName"
-    ConvertTo-Json $session | Out-File -Force -FilePath "~\.aws\cli\cache\$tempProfile.json"
+    $env:AWS_DEFAULT_REGION = $env:AWS_REGION
 }
 
-function Set-AssumeRole([string]$profileName, [string]$sourceProfile, [string]$mfaArn, [string]$roleArn, [switch]$refresh) {
-    Set-Session $sourceProfile $mfaArn $refresh
-    $session = aws sts assume-role --role-arn $roleArn --role-session-name "awsume-temp-$profileName-$(Get-Random)" --output json | ConvertFrom-Json
+function Set-AssumeRole([string]$profileName, [string]$sourceProfile, [string]$roleArn, [bool]$r) {
+    Set-Session $sourceProfile $r
+    $session = aws sts assume-role --role-arn $roleArn --role-session-name "$profileName-$(Get-Random)" --output json | ConvertFrom-Json
     Set-Environment $profileName $session
+    Write-Host "#Role Credentials ($profileName) expire:" $session.Credentials.Expiration
 }
 
-Remove-AwsEnvs
-$profileName = Get-ProfileName $profileName
-$sourceProfile = Get-SourceProfile $profileName # Will be used for assuming roles
-$roleArn = Get-RoleArn $profileName # Will be used for assuming roles
-$mfaArn = Get-MfaArn $profileName
-$assumeRole = -Not [string]::IsNullOrWhiteSpace($sourceProfile) -and -Not [string]::IsNullOrWhiteSpace($roleArn)
+#Remove the environment variables associated with the AWS CLI,
+#ensuring all environment variables will be valid
+$env:AWS_SECRET_ACCESS_KEY = ""
+$env:AWS_SESSION_TOKEN = ""
+$env:AWS_SECURITY_TOKEN = ""
+$env:AWS_ACCESS_KEY_ID = ""
+$env:AWS_REGION = ""
+$env:AWS_DEFAULT_REGION = ""
 
-if ($assumeRole) {
-    Set-AssumeRole $profileName $sourceProfile $mfaArn $roleArn $refresh
+#validate the profileName, if parameter is empty, set it to default
+if ($d -eq $false -or [string]::IsNullOrWhiteSpace($profileName)) {
+        $profileName = "default"
+}
+
+#get the source profile, if there is none, set it to profile name
+$sourceProfile = aws configure get source_profile --profile $profileName
+if ([string]::IsNullOrWhiteSpace($sourceProfile)) {
+    [bool]$AWSUME_IS_USER=$true
+    $sourceProfile = $profileName
+}
+
+if ($AWSUME_IS_USER) {
+    Set-Session $profileName $r
 }
 else {
-    Set-Session $profileName $mfaArn $refresh
+    $roleArn = aws configure get role_arn --profile $profileName
+    Set-AssumeRole $profileName $sourceProfile $roleArn $r
 }
+
+#IF SHOW THEN SHOW COMMANDS

--- a/awsume.ps1
+++ b/awsume.ps1
@@ -90,3 +90,11 @@ else {
 }
 
 #IF SHOW THEN SHOW COMMANDS
+if ($s){
+    Write-Host "`$env:AWS_SECRET_ACCESS_KEY =" $env:AWS_SECRET_ACCESS_KEY
+    Write-Host "`$env:AWS_SESSION_TOKEN =" $env:AWS_SESSION_TOKEN
+    Write-Host "`$env:AWS_SECURITY_TOKEN =" $env:AWS_SECURITY_TOKEN
+    Write-Host "`$env:AWS_ACCESS_KEY_ID =" $env:AWS_ACCESS_KEY_ID
+    Write-Host "`$env:AWS_REGION =" $env:AWS_REGION
+    Write-Host "`$env:AWS_DEFAULT_REGION =" $env:AWS_DEFAULT_REGION
+}


### PR DESCRIPTION
# AWSume for Bash
I recreated the AWSume script for Bash, starting from scratch, but referencing the old AWSume script for Bash. It now works more like the AWSume PowerShell script, but Linux friendly.

This script is more modular, emulating the PowerShell script.

There are three command-line options this script accepts: `-s`, `-r`, and `-d`:
 - `-s` displays, to the console, the commands required to assume the role just assumed by the script.
 - `-r` will refresh the session no matter what. The user will have to enter their MFA code even if they just used the script on the same profile.
 - `-d` will assume the role of the default profile.

It is used in a similar fashion to the PowerShell script, too. To use this script, 
``` awsume [ profile_name ] [ flags ] ```
