### PR TITLE
Save temp.txt and null files into local .aws folder

### DIFF
--- a/awsume/shellScripts/awsume.bat
+++ b/awsume/shellScripts/awsume.bat
@@ -2,8 +2,8 @@
 
 set SHOW=
 
-awsumepy %* > ./temp.txt
-set /p AWSUME_TEXT=<./temp.txt
+awsumepy %* > %HOME%/.aws/awsume-temp.txt
+set /p AWSUME_TEXT=<%HOME%/.aws/awsume-temp.txt
 
 FOR %%A IN (%*) DO (
     IF "%%A"=="-s" (set "SHOW=y")
@@ -69,7 +69,7 @@ for /f "tokens=1,2,3,4,5,6 delims= " %%a in ("%AWSUME_TEXT%") do (
         set AWS_PROFILE=
         set AWS_DEFAULT_PROFILE=
         set AWSUME_PROFILE=
-        taskkill /FI "WindowTitle eq autoawsume" > null 2>&1
+        taskkill /FI "WindowTitle eq autoawsume" > %HOME%/.aws/awsume-null 2>&1
     )
     if "%%a" == "Stop" (
         if "auto-refresh-%%b" == "%AWS_PROFILE%" (
@@ -120,4 +120,3 @@ for /f "tokens=1,2,3,4,5,6 delims= " %%a in ("%AWSUME_TEXT%") do (
         )
     )
 )
-


### PR DESCRIPTION
This prevents polluting the user directories or require adding to a .gitignore.

Saving the temp.txt and null files into the current working directory can only be justified if the assumed profile can change depending on the directory.

Also the files are neither temporary nor particularly descriptive, hence the 'awsume-' prefix was added.`