### PR TITLE
Use existing session token if one exists

### DIFF
--- a/awsume/awsumepy.py
+++ b/awsume/awsumepy.py
@@ -258,6 +258,8 @@ def merge_role_and_source_profile(role_profile, source_profile):
     if valid_profile(source_profile):
         role_profile['aws_access_key_id'] = source_profile['aws_access_key_id']
         role_profile['aws_secret_access_key'] = source_profile['aws_secret_access_key']
+        if 'aws_session_token' not in role_profile and 'aws_session_token' in source_profile:
+            role_profile['aws_session_token'] = source_profile['aws_session_token']
         if 'mfa_serial' not in role_profile and 'mfa_serial' in source_profile:
             role_profile['mfa_serial'] = source_profile['mfa_serial']
         if 'region' not in role_profile and 'region' in source_profile:
@@ -860,6 +862,17 @@ def get_user_session(app, args, profiles, cache_path, user_session):
         credentials = {
             'AccessKeyId' : profile.get('aws_access_key_id'),
             'SecretAccessKey' : profile.get('aws_secret_access_key'),
+            'SessionToken' : profile.get('aws_session_token'),
+            'region' : profile.get('region')
+        }
+        return credentials
+
+    if 'aws_session_token' in profile:
+        LOG.debug('Profile has an existing session_token, using it')
+        credentials = {
+            'AccessKeyId' : profile.get('aws_access_key_id'),
+            'SecretAccessKey' : profile.get('aws_secret_access_key'),
+            'SessionToken' : profile.get('aws_session_token'),
             'region' : profile.get('region')
         }
         return credentials


### PR DESCRIPTION
Use an existing session_token from the source profile if one already exists.

Our specific use case is:
1. An external tool (aws-azure-login) is used to gain a temporary session token to a master account
2. awsume is used to switch between different roles in different accounts as permitted by the policies in the master account

This should help with https://github.com/trek10inc/awsume/issues/46 as well.

I have not had a chance to validate this change against other typical use-cases - YMMV.