### PR TITLE
Use parse_time() from lib.profile after it moved to there.

### DIFF
--- a/awsume/awsumepy/lib/aws.py
+++ b/awsume/awsumepy/lib/aws.py
@@ -125,5 +125,5 @@ def assume_role_with_saml(
     except Exception as e:
         raise RoleAuthenticationError(str(e))
     logger.debug('Role credentials received')
-    safe_print('Role credentials will expire {}'.format(parse_time(role_session['Expiration'])), colorama.Fore.GREEN)
+    safe_print('Role credentials will expire {}'.format(profile_lib.parse_time(role_session['Expiration'])), colorama.Fore.GREEN)
     return role_session


### PR DESCRIPTION
Resolves crash when fetching credentials with SAML.

```
Traceback (most recent call last):
  File "/Users/n1508035/.local/share/virtualenvs/awsume-lm-saml-plugin-Qm4G-w3w/bin/awsumepy", line 10, in <module>
    sys.exit(main())
  File "/Users/n1508035/.local/share/virtualenvs/awsume-lm-saml-plugin-Qm4G-w3w/lib/python3.7/site-packages/awsume/awsumepy/main.py", line 29, in main
    run_awsume(sys.argv[1:])
  File "/Users/n1508035/.local/share/virtualenvs/awsume-lm-saml-plugin-Qm4G-w3w/lib/python3.7/site-packages/awsume/awsumepy/main.py", line 17, in run_awsume
    awsume.run(argument_list)
  File "/Users/n1508035/.local/share/virtualenvs/awsume-lm-saml-plugin-Qm4G-w3w/lib/python3.7/site-packages/awsume/awsumepy/app.py", line 262, in run
    credentials = self.get_credentials(args, profiles)
  File "/Users/n1508035/.local/share/virtualenvs/awsume-lm-saml-plugin-Qm4G-w3w/lib/python3.7/site-packages/awsume/awsumepy/app.py", line 192, in get_credentials
    credentials = self.get_saml_credentials(args)
  File "/Users/n1508035/.local/share/virtualenvs/awsume-lm-saml-plugin-Qm4G-w3w/lib/python3.7/site-packages/awsume/awsumepy/app.py", line 163, in get_saml_credentials
    role_duration=role_duration,
  File "/Users/n1508035/.local/share/virtualenvs/awsume-lm-saml-plugin-Qm4G-w3w/lib/python3.7/site-packages/awsume/awsumepy/lib/aws.py", line 128, in assume_role_with_saml
    safe_print('Role credentials will expire {}'.format(parse_time(role_session['Expiration'])), colorama.Fore.GREEN)
NameError: name 'parse_time' is not defined
```