### PR TITLE
SAML profiles

### DIFF
--- a/awsume/awsumepy/app.py
+++ b/awsume/awsumepy/app.py
@@ -140,7 +140,7 @@ class Awsume(object):
             if args.role_arn:
                 choice = difflib.get_close_matches(args.role_arn, roles, cutoff=0)[0]
                 safe_print('Closest match: {}'.format(choice))
-            if args.profile_name:
+            elif args.profile_name:
                 profile_role_arn = profiles.get(args.profile_name, {}).get('role_arn')
                 principal_arn = profiles.get(args.profile_name, {}).get('principal_arn')
                 if profile_role_arn is None or principal_arn is None:

--- a/awsume/awsumepy/app.py
+++ b/awsume/awsumepy/app.py
@@ -142,14 +142,14 @@ class Awsume(object):
                 safe_print('Closest match: {}'.format(choice))
             if args.profile_name:
                 profile_role_arn = profiles.get(args.profile_name, {}).get('role_arn')
-                if profile_role_arn is None:
+                principal_arn = profiles.get(args.profile_name, {}).get('principal_arn')
+                if profile_role_arn is None or principal_arn is None:
                     raise exceptions.InvalidProfileError(args.profile_name)
-                # FIXME: It's possible to get a different role_arn than expected because of
-                # get_close_matches() fuzziness.
-                if profile_role_arn in roles:
-                    choice = profile_role_arn
+                principal_plus_profile_role_arn = ','.join([principal_arn, profile_role_arn])
+                if principal_plus_profile_role_arn in roles:
+                    choice = principal_plus_profile_role_arn
                 else:
-                    raise exceptions.SAMLRoleNotFoundError(profile_role_arn)
+                    raise exceptions.SAMLRoleNotFoundError(principal_arn, profile_role_arn)
                 safe_print('Match: {}'.format(choice))
             else:
                 for index, choice in enumerate(roles):

--- a/awsume/awsumepy/lib/exceptions.py
+++ b/awsume/awsumepy/lib/exceptions.py
@@ -52,11 +52,12 @@ class SAMLAssertionMissingRoleError(Exception):
 
 class SAMLRoleNotFoundError(Exception):
     """"""
-    def __init__(self, role_arn, message=''):
+    def __init__(self, principal_arn, role_arn, message=''):
         self.role_arn = role_arn
+        self.principal_arn = principal_arn
         self.message = message
     def __str__(self):
-        return self.message if self.message else 'No match for SAML provider and role: {}'.format(self.role_arn)
+        return self.message if self.message else 'No match for SAML principal and role: {},{}'.format(self.principal_arn, self.role_arn)
 
 
 class SAMLAssertionParseError(Exception):

--- a/awsume/awsumepy/lib/exceptions.py
+++ b/awsume/awsumepy/lib/exceptions.py
@@ -50,6 +50,15 @@ class SAMLAssertionMissingRoleError(Exception):
         return self.message if self.message else 'No role in the SAML assertion'
 
 
+class SAMLRoleNotFoundError(Exception):
+    """"""
+    def __init__(self, role_arn, message=''):
+        self.role_arn = role_arn
+        self.message = message
+    def __str__(self):
+        return self.message if self.message else 'No match for SAML provider and role: {}'.format(self.role_arn)
+
+
 class SAMLAssertionParseError(Exception):
     """"""
     def __init__(self, message=''):

--- a/awsume/awsumepy/lib/profile.py
+++ b/awsume/awsumepy/lib/profile.py
@@ -170,7 +170,16 @@ def format_aws_profiles(profiles: dict, get_extra_data: bool) -> list: # pragma:
             profile = sorted_profiles[name]
             is_role_profile = 'role_arn' in profile
             profile_type = 'Role' if is_role_profile else 'User'
-            source_profile = profile.get('source_profile')
+            # Assume source_profile is None unless we find otherwise afterwards.
+            if is_role_profile:
+                if 'source_profile' in profile.keys():
+                    source_profile = profile['source_profile']
+                elif 'principal_arn' in profile.keys():
+                    source_profile = profile['principal_arn'].split(':')[-1]
+                else:
+                    source_profile = 'None'
+            else:
+                source_profile = 'None'
             mfa_needed = 'Yes' if 'mfa_serial' in profile else 'No'
             profile_region = str(profile.get('region'))
             profile_account_id = get_account_id(profile, get_extra_data)

--- a/awsume/awsumepy/lib/profile.py
+++ b/awsume/awsumepy/lib/profile.py
@@ -58,7 +58,7 @@ def validate_profile(profiles: dict, target_profile_name: str) -> bool:
             raise InvalidProfileError(target_profile_name, message='awsume does not support the credential_process profile option: {}')
         if profile.get('credential_source') and profile.get('source_profile'):
             raise InvalidProfileError(target_profile_name, message='credential_source and source_profile are mutually exclusive profile options')
-        if not profile.get('credential_source') and not profile.get('source_profile'):
+        if not profile.get('credential_source') and not profile.get('source_profile') and not profile.get('principal_arn'):
             raise InvalidProfileError(target_profile_name, message='role profiles must contain one of credential_source or source_profile')
         if profile.get('credential_source') not in VALID_CREDENTIAL_SOURCES:
             raise InvalidProfileError(target_profile_name, message='unsupported awsume credential_source profile option: {}'.format(profile.get('credential_source')))


### PR DESCRIPTION
Add profile support for `--with-saml`

```
configuration
[my-profile]
role_arn = <saml_provider_arn>,<role_arn>
```

I'm possibly misusing role_arn in the credentials file by having it include both the SAML provider ARN and role_arn but the other option was to add a non-standard config value to the credentials file.