### PR TITLE
Feature: Added export of Expiration time to Env

### DIFF
--- a/awsume/awsumepy/app.py
+++ b/awsume/awsumepy/app.py
@@ -280,6 +280,7 @@ class Awsume(object):
                     str(credentials.get('Region')),
                     str(args.target_profile_name),
                     str(credentials.get('AwsProfile')),
+                    str(credentials.get('Expiration').strftime('%Y-%m-%dT%H:%M:%S')),
                 ])
         except exceptions.EarlyExit:
             logger.debug('', exc_info=True)

--- a/docs/general/usage.md
+++ b/docs/general/usage.md
@@ -66,6 +66,7 @@ export AWS_SECURITY_TOKEN=<SECRET>
 export AWS_REGION=<REGION>
 export AWS_DEFAULT_REGION=<REGION>
 export AWSUME_PROFILE=my-admin
+export AWSUME_EXPIRATION=<YYYY-mm-ddTHH:MM:SS>
 ```
 
 This way you can easily get credentials to another shell session, for instance through ssh.

--- a/shell_scripts/awsume
+++ b/shell_scripts/awsume
@@ -2,7 +2,7 @@
 
 #AWSUME_FLAG - what awsumepy told the shell to do
 #AWSUME_n - the data from awsumepy
-read AWSUME_FLAG AWSUME_1 AWSUME_2 AWSUME_3 AWSUME_4 AWSUME_5 AWSUME_6 <<< $(awsumepy "$@")
+read AWSUME_FLAG AWSUME_1 AWSUME_2 AWSUME_3 AWSUME_4 AWSUME_5 AWSUME_6 AWSUME_7 <<< $(awsumepy "$@")
 # remove carraige return
 AWSUME_FLAG=$(echo "$AWSUME_FLAG" | tr -d '\r')
 
@@ -28,6 +28,7 @@ elif [ "$AWSUME_FLAG" = "Auto" ]; then
   unset AWS_PROFILE
   unset AWS_DEFAULT_PROFILE
   unset AWSUME_PROFILE
+  unset AWSUME_EXPIRATION
   export AWS_PROFILE=${AWSUME_1}
   export AWS_DEFAULT_PROFILE=${AWSUME_1}
   if [ ! "${AWSUME_2}" = "None" ]; then
@@ -51,6 +52,7 @@ elif [ "$AWSUME_FLAG" = "Unset" ]; then
   unset AWS_REGION
   unset AWS_DEFAULT_REGION
   unset AWSUME_PROFILE
+  unset AWSUME_EXPIRATION
   for AWSUME_var in "$@"
   do
     if [[ "$AWSUME_var" == "-s"* ]]; then
@@ -63,6 +65,7 @@ elif [ "$AWSUME_FLAG" = "Unset" ]; then
       echo unset AWS_REGION
       echo unset AWS_DEFAULT_REGION
       echo unset AWSUME_PROFILE
+      echo unset AWSUME_EXPIRATION
     fi
   done
   return
@@ -78,6 +81,7 @@ elif [ "$AWSUME_FLAG" = "Kill" ]; then
   unset AWS_REGION
   unset AWS_DEFAULT_REGION
   unset AWSUME_PROFILE
+  unset AWSUME_EXPIRATION
   return
 
 
@@ -97,6 +101,7 @@ elif [ "$AWSUME_FLAG" = "Awsume" ]; then
   unset AWS_REGION
   unset AWS_DEFAULT_REGION
   unset AWS_PROFILE
+  unset AWSUME_EXPIRATION
   unset AWS_DEFAULT_PROFILE
   unset AWSUME_PROFILE
 
@@ -122,6 +127,9 @@ elif [ "$AWSUME_FLAG" = "Awsume" ]; then
     export AWS_PROFILE=${AWSUME_6}
     export AWS_DEFAULT_PROFILE=${AWSUME_6}
   fi
+  if [ ! "${AWSUME_7}" = "None" ]; then
+    export AWSUME_EXPIRATION=${AWSUME_7}
+  fi
   for AWSUME_var in "$@"
   do
     if [[ "$AWSUME_var" == "-s"* ]]; then
@@ -145,6 +153,9 @@ elif [ "$AWSUME_FLAG" = "Awsume" ]; then
       if [ ! "${AWSUME_6}" = "None" ]; then
         echo export AWS_PROFILE=${AWSUME_6}
         echo export AWS_DEFAULT_PROFILE=${AWSUME_6}
+      fi
+      if [ ! "${AWSUME_6}" = "None" ]; then
+        echo export AWSUME_EXPIRATION=${AWSUME_7}
       fi
     fi
   done

--- a/shell_scripts/awsume
+++ b/shell_scripts/awsume
@@ -154,7 +154,7 @@ elif [ "$AWSUME_FLAG" = "Awsume" ]; then
         echo export AWS_PROFILE=${AWSUME_6}
         echo export AWS_DEFAULT_PROFILE=${AWSUME_6}
       fi
-      if [ ! "${AWSUME_6}" = "None" ]; then
+      if [ ! "${AWSUME_7}" = "None" ]; then
         echo export AWSUME_EXPIRATION=${AWSUME_7}
       fi
     fi

--- a/shell_scripts/awsume.bat
+++ b/shell_scripts/awsume.bat
@@ -9,7 +9,7 @@ FOR %%A IN (%*) DO (
     IF "%%A"=="-s" (set "SHOW=y")
 )
 
-for /f "tokens=1,2,3,4,5,6,7 delims= " %%a in ("%AWSUME_TEXT%") do (
+for /f "tokens=1,2,3,4,5,6,7,8 delims= " %%a in ("%AWSUME_TEXT%") do (
     if "%%a" == "Auto" (
         set AWS_SECRET_ACCESS_KEY=
         set AWS_SESSION_TOKEN=
@@ -20,6 +20,7 @@ for /f "tokens=1,2,3,4,5,6,7 delims= " %%a in ("%AWSUME_TEXT%") do (
         set AWS_PROFILE=
         set AWS_DEFAULT_PROFILE=
         set AWSUME_PROFILE=
+        set AWSUME_EXPIRATION=
 
         set AWS_PROFILE=%%b
         set AWS_DEFAULT_PROFILE=%%b
@@ -53,6 +54,7 @@ for /f "tokens=1,2,3,4,5,6,7 delims= " %%a in ("%AWSUME_TEXT%") do (
         set AWS_PROFILE=
         set AWS_DEFAULT_PROFILE=
         set AWSUME_PROFILE=
+        set AWSUME_EXPIRATION=
 
         IF defined SHOW (
             echo set AWS_ACCESS_KEY_ID=
@@ -62,6 +64,7 @@ for /f "tokens=1,2,3,4,5,6,7 delims= " %%a in ("%AWSUME_TEXT%") do (
             echo set AWS_REGION=
             echo set AWS_DEFAULT_REGION=
             echo set AWSUME_PROFILE=
+            echo set AWSUME_EXPIRATION=
         )
     )
     if "%%a" == "Kill" (
@@ -74,6 +77,7 @@ for /f "tokens=1,2,3,4,5,6,7 delims= " %%a in ("%AWSUME_TEXT%") do (
         set AWS_PROFILE=
         set AWS_DEFAULT_PROFILE=
         set AWSUME_PROFILE=
+        set AWSUME_EXPIRATION=
         taskkill /FI "WindowTitle eq autoawsume" > null 2>&1
     )
     if "%%a" == "Stop" (
@@ -92,6 +96,7 @@ for /f "tokens=1,2,3,4,5,6,7 delims= " %%a in ("%AWSUME_TEXT%") do (
         set AWS_PROFILE=
         set AWS_DEFAULT_PROFILE=
         set AWSUME_PROFILE=
+        set AWSUME_EXPIRATION=
 
         set AWSUME_COMMAND=%*
         if "%%b" NEQ "None" (
@@ -114,6 +119,9 @@ for /f "tokens=1,2,3,4,5,6,7 delims= " %%a in ("%AWSUME_TEXT%") do (
         if "%%g" NEQ "None" (
             set AWS_PROFILE=%%g
             set AWS_DEFAULT_PROFILE=%%g)
+        
+        if "%%h" NEQ "None" (
+            set AWSUME_EXPIRATION=%%h)
 
         IF defined SHOW (
             for /f "tokens=1,2,3,4,5 delims= " %%a in ("%AWSUME_TEXT%") do (
@@ -136,6 +144,9 @@ for /f "tokens=1,2,3,4,5,6,7 delims= " %%a in ("%AWSUME_TEXT%") do (
                 if "%%g" NEQ "None" (
                     echo set AWS_PROFILE=%%g
                     echo set AWS_DEFAULT_PROFILE=%%g)
+                
+                if "%%h" NEQ "None" (
+                    echo set AWSUME_EXPIRATION=%%h)
             )
         )
     )

--- a/shell_scripts/awsume.ps1
+++ b/shell_scripts/awsume.ps1
@@ -2,7 +2,7 @@
 
 #AWSUME_FLAG - what awsumepy told the shell to do
 #AWSUME_n - the data from awsumepy
-$AWSUME_FLAG, $AWSUME_1, $AWSUME_2, $AWSUME_3, $AWSUME_4, $AWSUME_5, $AWSUME_6 = `
+$AWSUME_FLAG, $AWSUME_1, $AWSUME_2, $AWSUME_3, $AWSUME_4, $AWSUME_5, $AWSUME_6, $AWSUME_7 = `
 $(awsumepy $args) -split '\s+'
 
 #if incorrect flag/help
@@ -30,6 +30,7 @@ elseif ( $AWSUME_FLAG -eq "Auto" ) {
     $env:AWS_PROFILE = ""
     $env:AWS_DEFAULT_PROFILE = ""
     $env:AWSUME_PROFILE = ""
+    $env:AWSUME_EXPIRATION = ""
 
     #set the profile that will contain the session credentials
     $env:AWS_PROFILE = $AWSUME_1
@@ -59,6 +60,7 @@ elseif ( $AWSUME_FLAG -eq "Unset" ) {
     $env:AWS_PROFILE = ""
     $env:AWS_DEFAULT_PROFILE = ""
     $env:AWSUME_PROFILE = ""
+    $env:AWSUME_EXPIRATION = ""
 
     #show the commands to unset these environment variables
     if ($args -like "-s") {
@@ -71,6 +73,7 @@ elseif ( $AWSUME_FLAG -eq "Unset" ) {
         Write-Host "`$env:AWS_PROFILE = `"`""
         Write-Host "`$env:AWS_DEFAULT_PROFILE = `"`""
         Write-Host "`$env:AWSUME_PROFILE = `"`""
+        Write-Host "`$env:AWSUME_EXPIRATION = `"`""
     }
     exit
 }
@@ -85,6 +88,7 @@ elseif ( $AWSUME_FLAG -eq "Kill" ) {
     $env:AWS_PROFILE = ""
     $env:AWS_DEFAULT_PROFILE = ""
     $env:AWSUME_PROFILE = ""
+    $env:AWSUME_EXPIRATION = ""
     exit
 }
 elseif ( $AWSUME_FLAG -eq "Stop" ) {
@@ -107,6 +111,7 @@ elseif ( $AWSUME_FLAG -eq "Awsume") {
     $env:AWS_PROFILE = ""
     $env:AWS_DEFAULT_PROFILE = ""
     $env:AWSUME_PROFILE = ""
+    $env:AWSUME_EXPIRATION = ""
 
     $env:AWSUME_COMMAND=$args
     if ( $AWSUME_1 -ne "None" ) {
@@ -135,6 +140,10 @@ elseif ( $AWSUME_FLAG -eq "Awsume") {
         $env:AWS_DEFAULT_PROFILE = $AWSUME_6
     }
 
+    if ( $AWSUME_7 -ne "None" ) {
+        $env:AWSUME_EXPIRATION = $AWSUME_7
+    }
+
     #if enabled, show the exact commands to use in order to assume the role we just assumed
     if ($args -like "-s") {
         if ( $AWSUME_1 -ne "None" ) {
@@ -161,6 +170,10 @@ elseif ( $AWSUME_FLAG -eq "Awsume") {
         if ( $AWSUME_6 -ne "None" ) {
             Write-Host "`$env:AWS_PROFILE =" $AWSUME_6
             Write-Host "`$env:AWS_DEFAULT_PROFILE =" $AWSUME_6
+        }
+
+        if ( $AWSUME_7 -ne "None" ) {
+            Write-Host "`$env:AWSUME_EXPIRATION = $AWSUME_7"
         }
     }
 }

--- a/test/unit/awsume/awsumepy/test_app.py
+++ b/test/unit/awsume/awsumepy/test_app.py
@@ -1,6 +1,7 @@
 import sys
 import argparse
 import colorama
+import datetime
 import pluggy
 import pytest
 from io import StringIO
@@ -234,13 +235,13 @@ def test_run(__init__: MagicMock, isatty: MagicMock):
     obj.export_data = MagicMock()
     obj.get_credentials = MagicMock()
     obj.parse_args.return_value = argparse.Namespace(with_saml=False, with_web_identity=False, auto_refresh=False, target_profile_name='default', json=None)
-    obj.get_credentials.return_value = {'AccessKeyId': 'AKIA...', 'SecretAccessKey': 'SECRET', 'SessionToken': 'LONGSECRET', 'Region': 'us-east-1'}
+    obj.get_credentials.return_value = {'AccessKeyId': 'AKIA...', 'SecretAccessKey': 'SECRET', 'SessionToken': 'LONGSECRET', 'Region': 'us-east-1', 'Expiration': datetime.datetime.now()}
     isatty.return_value = True
 
     obj.run([])
 
     obj.export_data.assert_called_with(obj.parse_args.return_value, obj.get_profiles.return_value, obj.get_credentials.return_value, 'Awsume', [
-        'AKIA...', 'SECRET', 'LONGSECRET', 'us-east-1', 'default', 'None',
+        'AKIA...', 'SECRET', 'LONGSECRET', 'us-east-1', 'default', 'None', datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S'),
     ])
 
 
@@ -256,7 +257,7 @@ def test_run_auto_refresh(__init__: MagicMock, isatty: MagicMock):
     obj.export_data = MagicMock()
     obj.get_credentials = MagicMock()
     obj.parse_args.return_value = argparse.Namespace(with_saml=False, with_web_identity=False, auto_refresh=True, target_profile_name='default', json=None, output_profile=None)
-    obj.get_credentials.return_value = {'AccessKeyId': 'AKIA...', 'SecretAccessKey': 'SECRET', 'SessionToken': 'LONGSECRET', 'Region': 'us-east-1'}
+    obj.get_credentials.return_value = {'AccessKeyId': 'AKIA...', 'SecretAccessKey': 'SECRET', 'SessionToken': 'LONGSECRET', 'Region': 'us-east-1', 'Expiration': datetime.datetime.now()}
     isatty.return_value = True
 
     obj.run([])


### PR DESCRIPTION
In order to calculate time remaining before expiry of a session this will export an extra environment variable: AWSUME_EXPIRATION. With this the remaining time can be calculated and displayed in the prompt in order to determine whether you need to renew the session.

Example usage within `.zshrc`:
```
_timeremaining() {
  secs_future=$(date -j -f "%Y-%m-%dT%H:%M:%S" $1 +%s)
  secs_now=$(date +%s)
  secs_remaining=$(( $secs_future - $secs_now ))
  if [ "$secs_remaining" -lt "0" ]; then
  	echo "00:00"
  elif [ "$secs_remaining" -lt "3600" ]; then
  	gdate -d@$secs_remaining -u +%M:%S
  else
    gdate -d@$secs_remaining -u +%H:%M:%S
  fi
}

alias awsenvtimeremain='_awsenvtimeremain'
_awsenvtimeremain() {
  if [[ -v AWSUME_PROFILE ]]; then
    time_remain=$(_timeremaining $AWSUME_EXPIRATION)
    echo "$time_remain"
  fi
}
```
Then just call `awsenvtimeremain()` in your prompt definition.

<img width="266" alt="Screenshot 2020-04-08 at 13 13 47" src="https://user-images.githubusercontent.com/443813/78782978-d002f280-799a-11ea-84f4-fb7c94531a48.png">
