### PR TITLE
MANIFEST: Include LICENSE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
+include LICENSE
 include fastentrypoints.py


### PR DESCRIPTION
So that license text is available on PyPI archive.