### PR TITLE
XDG Base Directory Support

### DIFF
--- a/awsume/awsumepy/lib/config_management.py
+++ b/awsume/awsumepy/lib/config_management.py
@@ -32,6 +32,8 @@ operations:
 def load_config() -> dict:
     if not os.path.exists(str(constants.AWSUME_DIR)):
         os.makedirs(str(constants.AWSUME_DIR))
+    if not os.path.exists(str(constants.AWSUME_CONFIG)):
+        os.makedirs(str(constants.AWSUME_CONFIG.parent))
     if not os.path.isfile(str(constants.AWSUME_CONFIG)):
         open(str(constants.AWSUME_CONFIG), 'a').close()
 

--- a/awsume/awsumepy/lib/constants.py
+++ b/awsume/awsumepy/lib/constants.py
@@ -1,9 +1,22 @@
 from pathlib import Path
+import os
 
-AWSUME_DIR = Path('~/.awsume').expanduser()
-AWSUME_CONFIG = Path('~/.awsume' + '/config.yaml').expanduser()
+XDG_CONFIG_HOME = Path('~/.config').expanduser()
+if os.getenv('XDG_CONFIG_HOME'):
+    XDG_CONFIG_HOME = Path(os.getenv('XDG_CONFIG_HOME')).expanduser()
+
+XDG_DATA_HOME = Path('~/.local/share').expanduser()
+if os.getenv('XDG_DATA_HOME'):
+    XDG_DATA_HOME = Path(os.getenv('XDG_DATA_HOME')).expanduser()
+
+XDG_CACHE_HOME = Path('~/.cache').expanduser()
+if os.getenv('XDG_CACHE_HOME'):
+    XDG_CACHE_HOME = Path(os.getenv('XDG_CACHE_HOME')).expanduser()
+
+AWSUME_CONFIG = Path(str(XDG_CONFIG_HOME) + '/awsume/config.yaml')
+AWSUME_DIR = Path(str(XDG_DATA_HOME) + '/awsume')
+AWSUME_CACHE_DIR = Path(str(XDG_CACHE_HOME) + '/awsume')
 
 DEFAULT_CREDENTIALS_FILE = Path('~/.aws/credentials').expanduser()
 DEFAULT_CONFIG_FILE = Path('~/.aws/config').expanduser()
 
-AWSUME_CACHE_DIR = Path('~/.awsume/cache').expanduser()

--- a/docs/general/config.md
+++ b/docs/general/config.md
@@ -1,6 +1,8 @@
 # Config
 
-Awsume's configuration file can be found at `~/.awsume/config.yaml`.
+Awsume's configuration file can be found at `~/.config/awsume/config.yaml` by
+default. If the `XDG_CONFIG_HOME` environment variable is set then it can be
+found at: `${XDG_CONFIG_HOME}/awsume/config.yaml`.
 
 ## Properties
 

--- a/test/unit/awsume/awsumepy/lib/test_aws_files.py
+++ b/test/unit/awsume/awsumepy/lib/test_aws_files.py
@@ -10,6 +10,7 @@ from awsume.awsumepy.lib import constants
 from awsume.awsumepy.lib import aws_files
 
 
+@patch.dict('os.environ', {'AWS_CONFIG_FILE': '', 'AWS_SHARED_CREDENTIALS_FILE': ''}, clear=True)
 def test_get_aws_files():
     args = argparse.Namespace(config_file=None, credentials_file=None)
     config = {}
@@ -20,6 +21,7 @@ def test_get_aws_files():
     assert credentials_file == str(Path(constants.DEFAULT_CREDENTIALS_FILE))
 
 
+@patch.dict('os.environ', {'AWS_CONFIG_FILE': '', 'AWS_SHARED_CREDENTIALS_FILE': ''}, clear=True)
 def test_get_aws_files_args():
     args = argparse.Namespace(config_file='my/config/file', credentials_file='my/credentials/file')
     config = {}
@@ -31,6 +33,7 @@ def test_get_aws_files_args():
 
 
 
+@patch.dict('os.environ', {'AWS_CONFIG_FILE': '', 'AWS_SHARED_CREDENTIALS_FILE': ''}, clear=True)
 def test_get_aws_files_config():
     args = argparse.Namespace(config_file=None, credentials_file=None)
     config = {

--- a/test/unit/awsume/awsumepy/lib/test_config_management.py
+++ b/test/unit/awsume/awsumepy/lib/test_config_management.py
@@ -38,7 +38,7 @@ def test_load_config_no_path(exists: MagicMock, isfile: MagicMock, makedirs: Mag
     assert result == yaml_load.return_value
     makedirs.assert_called()
     open.assert_called_once()
-    makedirs.assert_called_once()
+    assert makedirs.call_count == 2
 
 
 @patch('yaml.safe_load')


### PR DESCRIPTION
Introduced support for XDG base directories to help user's home folder uncluttered, see issue: #132

- `AWSUME_DIR` has been set to `${XDG_DATA_HOME}/awsume`
- `AWSUME_CONFIG` is now defaulting to `${XDG_CONFIG_HOME}/awsume`
- `AWSUME_CACHE_DIR` is now `${XDG_CACHE_HOME}/awsume`

There is also some fixes to the unit tests for the AWS config files, there are now patches to ensure that the environment variables for the AWS config and credential files are not set.