### PR TITLE
fix SAML parsing to handle any XML prefix mapping

### DIFF
--- a/awsume/awsumepy/lib/saml.py
+++ b/awsume/awsumepy/lib/saml.py
@@ -15,8 +15,15 @@ def parse_assertion(assertion: str) -> list:
     if not xmltodict:
         raise ValidationException(message='SAML option not installed, try installing awsume[saml]')
 
+    namespaces = {
+        'urn:oasis:names:tc:SAML:2.0:protocol': 'saml2p',
+        'urn:oasis:names:tc:SAML:2.0:assertion': 'saml2',
+        'urn:oasis:names:tc:SAML:1.0:protocol': 'samlp',
+        'urn:oasis:names:tc:SAML:1.0:assertion': 'saml',
+    }
+
     roles = []
-    response = xmltodict.parse(base64.b64decode(assertion))
+    response = xmltodict.parse(base64.b64decode(assertion), process_namespaces=True, namespaces=namespaces, force_cdata=True)
 
     if response.get('saml2p:Response') is not None:
         attributes = response.get('saml2p:Response', {}).get('saml2:Assertion', {}).get('saml2:AttributeStatement', {}).get('saml2:Attribute', {})


### PR DESCRIPTION
Fix for #147.

The XML prefixes are not always samlp/saml/etc, so we provide a mapping to the XML parser so it can translate the namespaces into the prefixes we're expecting.

Also enable force_cdata, because in testing this I saw xmltodict returning a plain string rather than `{'#text': value})` whereas the code always expects it in the structured form. This ensures that xmltodict output matches the code.