### PR TITLE
fix specifying both role-arn and principal-arn as command-line arguments fails with TypeError

### DIFF
--- a/awsume/awsumepy/app.py
+++ b/awsume/awsumepy/app.py
@@ -129,7 +129,7 @@ class Awsume(object):
 
         if len(roles) > 1:
             if args.role_arn and args.principal_arn:
-                principal_plus_role_arn = ','.join(args.role_arn, args.principal_arn)
+                principal_plus_role_arn = ','.join([args.role_arn, args.principal_arn])
                 if self.config.get('fuzzy-match'):
                     choice = difflib.get_close_matches(principal_plus_role_arn, roles, cutoff=0)[0]
                     safe_print('Closest match: {}'.format(choice))


### PR DESCRIPTION
Fix for #149

```
  File "/usr/local/lib/python3.9/site-packages/awsume/awsumepy/app.py", line 132, in get_saml_credentials
    principal_plus_role_arn = ','.join(args.role_arn, args.principal_arn)
TypeError: str.join() takes exactly one argument (2 given)
```

This is the line of code, it's missing brackets:
`principal_plus_role_arn = ','.join(args.role_arn, args.principal_arn)`
should be:
`principal_plus_role_arn = ','.join([args.role_arn, args.principal_arn])`