### PR TITLE
Replace `autoawsume/main.py : logging.FileHandler` with rotation

### DIFF
--- a/awsume/autoawsume/main.py
+++ b/awsume/autoawsume/main.py
@@ -5,6 +5,7 @@ import time
 import sys
 import os
 import logging
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from datetime import datetime, timedelta
 import dateutil
@@ -80,14 +81,19 @@ def main():
 
 def configure_logger():
     log_dir = str(Path('~/.awsume/logs/').expanduser())
-    log_file = str(Path('~/.awsume/logs/autoawsume-{}'.format(datetime.now().strftime('%Y-%m-%d_%H:%M:%S:%f'))).expanduser())
+    log_file = str(Path('~/.awsume/logs/autoawsume.log').expanduser())
 
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
-    if not os.path.isfile(log_file):
-        open(log_file, 'a').close()
 
-    log_handler = logging.FileHandler(log_file)
+    log_handler = RotatingFileHandler(
+        filename=log_file,
+        maxBytes=(
+            10 * # ten
+            (2 ** 20) # megabytes
+        ),
+        backupCount=2,
+    )
     log_handler.setFormatter(LogFormatter('%(asctime)s | %(name)s | %(filename)s:%(funcName)s | [%(levelname)s] | %(message)s'))
     logger.addHandler(log_handler)
     logger.setLevel(logging.DEBUG)

--- a/awsume/autoawsume/main.py
+++ b/awsume/autoawsume/main.py
@@ -89,7 +89,7 @@ def configure_logger():
     log_handler = RotatingFileHandler(
         filename=log_file,
         maxBytes=(
-            10 * # ten
+            5 * # five
             (2 ** 20) # megabytes
         ),
         backupCount=2,


### PR DESCRIPTION
After using awsume for a little while on a new machine, I found a bit over 2GB
of logs from autoawsume in `~/.awsume/logs/`. It makes sense to have logs for
autoawsume to help diagnose issues, but I think maybe 10MB of logs for
autoawsume is the most a user would want to retain.

I also noticed the use of the long datetime stamping in the file names, which
makes rotation difficult. In the case there are multiple active autoawsumes,
the OS will interleave writes. This shouldn't be a problem, because python is
specific about disk flushing for logs so the worst that should occur is
interleaved lines (line 1 from process A, line 2-5 from process B, so forth).
To distinguish processes we could add PID, but I'm not sure what the windows
support is for reading PIDs.