### PR TITLE
fix: saml order of principal and role mixed

### DIFF
--- a/awsume/awsumepy/app.py
+++ b/awsume/awsumepy/app.py
@@ -143,7 +143,7 @@ class Awsume(object):
                 principal_arn = profiles.get(args.profile_name, {}).get('principal_arn')
                 if profile_role_arn is None or principal_arn is None:
                     raise exceptions.InvalidProfileError(args.profile_name, 'both role_arn and principal_arn are necessary for saml profiles')
-                principal_plus_profile_role_arn = ','.join([principal_arn, profile_role_arn])
+                principal_plus_profile_role_arn = ','.join([profile_role_arn, principal_arn])
                 if principal_plus_profile_role_arn in roles:
                     choice = principal_plus_profile_role_arn
                 else:
@@ -158,11 +158,13 @@ class Awsume(object):
                     choice = roles[int(response)]
                 else:
                     choice = difflib.get_close_matches(response, roles, cutoff=0)[0]
-            role_arn = choice.split(',')[1]
-            principal_arn = choice.split(',')[0]
         else:
-            role_arn = roles[0].split(',')[1]
-            principal_arn = roles[0].split(',')[0]
+            choice = roles[0]
+        for arn in choice.split(','):
+            if 'role' in arn:
+                role_arn = arn
+            if 'saml-provider' in arn:
+                principal_arn = arn
         safe_print('Assuming role: {},{}'.format(principal_arn, role_arn), color=colorama.Fore.GREEN)
         credentials = aws_lib.assume_role_with_saml(
             role_arn,


### PR DESCRIPTION
Hi there,

I was just writing a saml plugin, realizing that it always came to issues because of the order between role arn and principal arn.
Fixes:
1. In the saml response, you get the arns like this: "role-arn,principal-arn" [1]
You had it correct once and [once](https://github.com/trek10inc/awsume/blob/efec1b0c063bedce081f7a89da16bc29fd40e166/awsume/awsumepy/app.py#L132) and than once the [other way around](https://github.com/trek10inc/awsume/blob/efec1b0c063bedce081f7a89da16bc29fd40e166/awsume/awsumepy/app.py#L146).
2. Parsing the actual role arn and principal arn from the saml response was also in the wrong order [here](https://github.com/trek10inc/awsume/blob/efec1b0c063bedce081f7a89da16bc29fd40e166/awsume/awsumepy/app.py#L161) and [here](https://github.com/trek10inc/awsume/blob/efec1b0c063bedce081f7a89da16bc29fd40e166/awsume/awsumepy/app.py#L164)

In case (1) differs from response to response I'd be glad to write a less static check here.

[1] At least this is how the response looked like I was receiving.