### PR TITLE
Fish-shell autocompletion includes filenames

### DIFF
--- a/awsume/configure/autocomplete.py
+++ b/awsume/configure/autocomplete.py
@@ -23,7 +23,7 @@ _arguments "*: :($(awsume-autocomplete))"
 """
 
 FISH_AUTOCOMPLETE_SCRIPT = """
-complete --command awsume --arguments '(awsume-autocomplete)'
+complete -f --command awsume --arguments '(awsume-autocomplete)'
 """
 
 POWERSHELL_AUTOCOMPLETE_SCRIPT = """


### PR DESCRIPTION
The fish-shell autocompletion works marvelously, though there is one slight annoyance and a rather easy fix.

The file /home/$USER/.config/fish/completions/awsume.fish contains the following:

#Auto-Complete function for AWSume
complete --command awsume --arguments '(awsume-autocomplete)'
This however also means that when you use tab completion, you'll also include the CWD's files. Naturally, you cannot awsume to the files 😁

An easy fix would be to add the -f argument, not allowing files:

As per:

-f or --no-files says that this completion may not be followed by a filename.

Source:

https://fishshell.com/docs/current/cmds/complete.html


Related to #173 