### PR TITLE
adds quiet configuration option

### DIFF
--- a/awsume/awsumepy/lib/safe_print.py
+++ b/awsume/awsumepy/lib/safe_print.py
@@ -13,6 +13,8 @@ def safe_print(message: str, color: str = '', end: str = None):
     config = yaml.safe_load(open(str(AWSUME_CONFIG), 'r')) or {}
     if not config:
         config = {'colors': True}
+    if config.get('quiet', False):
+        return
     if os.name == 'nt' or config.get('colors') != True:
         color = ''
     print(str(color) + str(message) + colorama.Style.RESET_ALL, end=end, file=sys.stderr)


### PR DESCRIPTION
Hello!

This is my first PR to awsume, please let me know if I need to follow any particular guideline to contribute. 

The PR adds a new configuration option - `quiet`. The option is similar to what many CLIs have - if `quiet` is true then do not print anything. 

The use case of this configuration option is to have a clean output when `awsume` is used from shell scripts. My personal use case - I invoke `awsume` every time I open a terminal by putting something like `awsume -a myprofile` into my shell's init script (I am using fish so it is in `~/.config/fish/config.fish`). With `quiet: true` my terminal opens without any extra output from awsume. If I remove `quiet: true` then my terminal will look like:

```bash
Session token will expire at 2022-03-31 04:20:28
[123] Role credentials will expire 2022-03-30 19:55:58
~
> 
``` 

Well, I hope you get the drill - this is basically the "work quietly" option like `-q` in `grep`. 

Also, I actually wanted to make it an argument rather than configuration option. So, I would prefer to type `awsume -q -a myprofile` rather than putting  `quiet: false` into `~/.awsume/config.yaml`. However, I found it would require more changes then just a couple of lines, since I would somehow need to pass arguments to `safe_print` function. Please let me know where do  you stand on it. 

Thank you! 

Awesome CLI by the way, saves me a lot of time. 
