### PR TITLE
Add session tagging possibility

### DIFF
--- a/awsume/awsumepy/lib/aws.py
+++ b/awsume/awsumepy/lib/aws.py
@@ -40,6 +40,7 @@ def assume_role(
     role_duration: int = None,
     mfa_serial: str = None,
     mfa_token: str = None,
+    tags: list | None = None,
 ) -> dict:
     if len(session_name) < 2:
         session_name = session_name.center(2, '_')
@@ -62,6 +63,8 @@ def assume_role(
         if mfa_serial:
             kwargs['SerialNumber'] = mfa_serial
             kwargs['TokenCode'] = mfa_token or profile_lib.get_mfa_token()
+        if tags:
+            kwargs["Tags"] = tags
         logger.debug('Assuming role now')
         role_session = role_sts_client.assume_role(**kwargs).get('Credentials')
         logger.debug('Received role credentials')


### PR DESCRIPTION
I noticed the need to tag STS sessions in several cases, in addition, there is also an issue with such a proposal: https://github.com/trek10inc/awsume/issues/128

In this PR, I decided to prepare a solution that allows you to tag STS sessions using a new `-t` (`--tags`) _[Key=Value,Key2=Value2,...]_ parameter.