### PR TITLE
#172 Default user expiration

### DIFF
--- a/awsume/awsumepy/default_plugins.py
+++ b/awsume/awsumepy/default_plugins.py
@@ -563,6 +563,10 @@ def get_credentials_handler(config: dict, arguments: argparse.Namespace, profile
                 user_session = get_credentials_from_credential_source(config, arguments, profiles, target_profile, profile_name)
             else:
                 user_session = get_credentials_no_mfa(config, arguments, profiles, target_profile)
+                user_session["Expiration"] = user_session.get("Expiration", (
+                    lambda d: d.replace(d.year + 1, tzinfo=dateutil.tz.tzlocal())
+                )(datetime.now()))
+
 
     if config.get('is_interactive'):
         if user_session and user_session.get('Expiration'):


### PR DESCRIPTION
Default user expiration so auto doesn't fail to parse it
```
Traceback (most recent call last):
  File "/Users/aaronkelton/.local/bin/awsumepy", line 8, in <module>
    sys.exit(main())
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/main.py", line 29, in main
    run_awsume(sys.argv[1:])
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/main.py", line 17, in run_awsume
    awsume.run(argument_list)
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/app.py", line 263, in run
    credentials = self.get_credentials(args, profiles)
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/app.py", line 205, in get_credentials
    create_autoawsume_profile(self.config, args, profiles, credentials)
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/lib/autoawsume.py", line 18, in create_autoawsume_profile
    profile['expiration'] = role_session.get('Expiration').strftime('%Y-%m-%d %H:%M:%S')
AttributeError: 'NoneType' object has no attribute 'strftime'
```