### PR TITLE
Default user expiration

### DIFF
--- a/awsume/awsumepy/default_plugins.py
+++ b/awsume/awsumepy/default_plugins.py
@@ -1,25 +1,23 @@
 import argparse
-import configparser
 import json
 import os
-import colorama
 import subprocess
+
+import colorama
 import dateutil
 
-
-from . lib import exceptions
-from . hookimpl import hookimpl
+from .hookimpl import hookimpl
+from .lib import aws as aws_lib
+from .lib import aws_files as aws_files_lib
+from .lib import config_management as config_lib
+from .lib import exceptions
+from .lib import profile as profile_lib
+from .lib.logger import logger
+from .lib.profile import VALID_CREDENTIAL_SOURCES
+from .lib.profile import get_role_chain, get_profile_name
+from .lib.safe_print import safe_print
 from .. import __data__
 from ..autoawsume.process import kill
-from . lib import aws as aws_lib
-from . lib import aws_files as aws_files_lib
-from . lib.logger import logger
-from . lib.safe_print import safe_print
-from . lib import config_management as config_lib
-from . lib import profile as profile_lib
-from . lib import cache as cache_lib
-from . lib.profile import VALID_CREDENTIAL_SOURCES
-from . lib.profile import get_role_chain, get_profile_name
 
 
 def custom_duration_argument_type(string):
@@ -592,9 +590,6 @@ def get_credentials_handler(config: dict, arguments: argparse.Namespace, profile
                 user_session = get_credentials_from_credential_source(config, arguments, profiles, target_profile, profile_name)
             else:
                 user_session = get_credentials_no_mfa(config, arguments, profiles, target_profile)
-                user_session["Expiration"] = user_session.get("Expiration", (
-                    lambda d: d.replace(d.year + 1, tzinfo=dateutil.tz.tzlocal())
-                )(datetime.now()))
 
 
     if config.get('is_interactive'):

--- a/awsume/awsumepy/default_plugins.py
+++ b/awsume/awsumepy/default_plugins.py
@@ -592,6 +592,10 @@ def get_credentials_handler(config: dict, arguments: argparse.Namespace, profile
                 user_session = get_credentials_from_credential_source(config, arguments, profiles, target_profile, profile_name)
             else:
                 user_session = get_credentials_no_mfa(config, arguments, profiles, target_profile)
+                user_session["Expiration"] = user_session.get("Expiration", (
+                    lambda d: d.replace(d.year + 1, tzinfo=dateutil.tz.tzlocal())
+                )(datetime.now()))
+
 
     if config.get('is_interactive'):
         if user_session and user_session.get('Expiration'):

--- a/awsume/awsumepy/lib/autoawsume.py
+++ b/awsume/awsumepy/lib/autoawsume.py
@@ -15,7 +15,8 @@ def create_autoawsume_profile(config: dict, arguments: argparse.Namespace, profi
         raise exceptions.ImmutableProfileError(autoawsume_profile_name, 'not awsume-managed')
     profile = profile_lib.credentials_to_profile(role_session)
     profile['autoawsume'] = 'true'
-    profile['expiration'] = role_session.get('Expiration').strftime('%Y-%m-%d %H:%M:%S')
+    if 'Expiration' in role_session:
+        profile['expiration'] = role_session.get('Expiration').strftime('%Y-%m-%d %H:%M:%S')
     if 'SourceExpiration' in role_session:
         profile['source_expiration'] = role_session.get('SourceExpiration').strftime('%Y-%m-%d %H:%M:%S')
     profile['awsumepy_command'] = ' '.join(arguments.system_arguments)

--- a/test/unit/awsume/awsumepy/lib/test_autoawsume.py
+++ b/test/unit/awsume/awsumepy/lib/test_autoawsume.py
@@ -31,3 +31,28 @@ def test_create_autoawsume_profile(profile: MagicMock, aws_files: MagicMock):
         'source_expiration': now_str,
         'awsumepy_command': 'awsumepy profile',
     }, 'credentials/file', True)
+
+
+@patch.object(autoawsume, 'aws_files_lib')
+@patch.object(autoawsume, 'profile_lib')
+def test_create_autoawsume_profile_no_expiration(profile: MagicMock, aws_files: MagicMock):
+    aws_files.get_aws_files.return_value = 'config/file', 'credentials/file'
+    profile.credentials_to_profile.return_value = {
+        'aws_access_key_id': 'AKIA...',
+        'aws_secret_access_key': 'SECRET',
+        'aws_session_token': 'LONG',
+    }
+    config = {}
+    profiles = {}
+    role_session = {}
+    args = argparse.Namespace(target_profile_name='profile', system_arguments=['awsumepy', 'profile'], output_profile=None)
+
+    autoawsume.create_autoawsume_profile(config, args, profiles, role_session)
+
+    aws_files.add_section.assert_called_with('autoawsume-profile', {
+        'aws_access_key_id': 'AKIA...',
+        'aws_secret_access_key': 'SECRET',
+        'aws_session_token': 'LONG',
+        'autoawsume': 'true',
+        'awsumepy_command': 'awsumepy profile',
+    }, 'credentials/file', True)


### PR DESCRIPTION
Default user expiration so auto doesn't fail to parse it
relates to #172 
```
Traceback (most recent call last):
  File "/Users/aaronkelton/.local/bin/awsumepy", line 8, in <module>
    sys.exit(main())
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/main.py", line 29, in main
    run_awsume(sys.argv[1:])
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/main.py", line 17, in run_awsume
    awsume.run(argument_list)
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/app.py", line 263, in run
    credentials = self.get_credentials(args, profiles)
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/app.py", line 205, in get_credentials
    create_autoawsume_profile(self.config, args, profiles, credentials)
  File "/Users/aaronkelton/.local/pipx/venvs/awsume/lib/python3.10/site-packages/awsume/awsumepy/lib/autoawsume.py", line 18, in create_autoawsume_profile
    profile['expiration'] = role_session.get('Expiration').strftime('%Y-%m-%d %H:%M:%S')
AttributeError: 'NoneType' object has no attribute 'strftime'
```