### PR TITLE
Python 3.12 no longer includes distutils

### DIFF
--- a/awsume/configure/alias.py
+++ b/awsume/configure/alias.py
@@ -1,5 +1,5 @@
 import os, pathlib
-from distutils.spawn import find_executable
+from shutil import which
 
 DEFAULT_ALIAS = 'alias awsume="source awsume"'
 PYENV_ALIAS = r'alias awsume="source \$(pyenv which awsume)"'
@@ -9,12 +9,12 @@ FISH_ALIAS = r'alias awsume="source (which awsume.fish)"'
 def main(shell: str, alias_file: str):
     alias_file = str(pathlib.Path(alias_file).expanduser())
     if shell == 'fish':
-        if find_executable('pyenv'):
+        if which('pyenv'):
             alias = PYENV_FISH_ALIAS
         else:
             alias = FISH_ALIAS
     else:
-        if find_executable('pyenv'):
+        if which('pyenv'):
             alias = PYENV_ALIAS
         else:
             alias = DEFAULT_ALIAS

--- a/awsume/configure/main.py
+++ b/awsume/configure/main.py
@@ -1,6 +1,6 @@
 import argparse, os, sys, subprocess
 from pathlib import Path
-from distutils.spawn import find_executable
+from shutil import which
 
 from . import alias, autocomplete
 
@@ -143,13 +143,13 @@ def run(shell: str = None, alias_file: str = None, autocomplete_file: str = None
         'fish': setup_fish,
     }
     if not shell:
-        if find_executable('bash'):
+        if which('bash'):
             setup_functions['bash'](None, None)
-        if find_executable('zsh'):
+        if which('zsh'):
             setup_functions['zsh'](None, None)
-        if find_executable('fish'):
+        if which('fish'):
             setup_functions['fish'](None, None)
-        if find_executable('powershell'):
+        if which('powershell'):
             setup_functions['powershell'](None, None)
     else:
         setup_functions[shell](alias_file, autocomplete_file)

--- a/awsume/configure/post_install.py
+++ b/awsume/configure/post_install.py
@@ -1,7 +1,4 @@
-import os, subprocess, sys
-from pathlib import Path
 from setuptools.command.install import install
-from distutils.spawn import find_executable
 
 from .main import run
 


### PR DESCRIPTION
Replace the use of distutils `find_executable` with the standard library `shutil.which`