### PR TITLE
Add 'configure' extra with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'pyyaml',
     ],
     extras_require={
+        'configure': ['setuptools'],
         'saml': ['xmltodict'],
         'fuzzy': ['python-levenshtein'],
         'console': ['awsume-console-plugin'],


### PR DESCRIPTION
Fixes #238

I think this is the least-intrusive solution -- it could arguably be put into `install_requires`.

lmk if this should be paired with a callout in the docs -- one benefit of inclusion in `install_requires` is that it would mean no more affected users (unless including `setuptools` can break other stuff, which wouldn't surprise me)