### PR TITLE
Fixe broken tests due to pytest7 incompatibility.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ pylint = "*"
 botostubs = "*"
 pytest = "*"
 pytest-cov = "*"
-pytest-pythonpath = "*"
 coverage = "*"
 watchdog = "*"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-python_paths = awsume
+pythonpath = awsume
 markers =
     only: marks tests as the only one to run


### PR DESCRIPTION
  ## Summary

  As of pytest 7, the `pytest-pythonpath` plugin is no longer needed — pytest natively supports the `pythonpath` ini option (see [pytest-dev/pytest#9635](https://github.com/pytest-dev/pytest/discussions/9635)).

  This repo tracks `Pipfile` but not `Pipfile.lock`, so a fresh `pipenv install --dev` will install the latest pytest. With pytest 7+, the `python_paths` option from `pytest-pythonpath` causes a `ValueError`
  and the entire test suite fails to run. This PR fixes that by switching to the built-in `pythonpath` option.

 **Note:** Out of scope for this PR, but committing `Pipfile.lock` would pin dependency versions and prevent this class of breakage in the future.