### PR TITLE
use shlex.split() to correctly parse quoted arguments in credential_process

### DIFF
--- a/awsume/awsumepy/default_plugins.py
+++ b/awsume/awsumepy/default_plugins.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -588,7 +589,7 @@ def get_credentials_process_target_and_arguments(target_profile: dict):
     credential_process = target_profile.get("credential_process", None)
     if credential_process is None:
         raise exceptions.ValidationException(f"credential_process not found in profile: {json.dumps(target_profile)}")
-    parts = credential_process.split()
+    parts = shlex.split(credential_process)
     target = Path(parts[0]).expanduser() if len(parts) > 0 else None
     if target is None:
         logger.debug(f"Unable to find credentials target from provided process string: {credential_process}")

--- a/test/unit/awsume/awsumepy/test_default_plugins.py
+++ b/test/unit/awsume/awsumepy/test_default_plugins.py
@@ -1079,3 +1079,16 @@ def test_get_credentials_process_target_and_arguments_expands_user():
     expected = [str(expanded_process_file), "arg1", "arg2"]
     actual = default_plugins.get_credentials_process_target_and_arguments(target_profile)
     assert actual == expected
+
+
+def test_get_credentials_process_target_and_arguments_expands_user_args_containcontains_space():
+    process_file = Path(f"~/test.sh")
+    expanded_process_file = process_file.expanduser()
+    expanded_process_file.open('w').close()
+    target_profile = {
+        "credential_process": f"{str(process_file)} 'arg1 with space' 'arg2 with space'"
+    }
+    print(target_profile)
+    expected = [str(expanded_process_file), "arg1 with space", "arg2 with space"]
+    actual = default_plugins.get_credentials_process_target_and_arguments(target_profile)
+    assert actual == expected


### PR DESCRIPTION
`str.split()` splits on all whitespace without respecting shell quoting, causing a shell error when credential_process contains quoted arguments (e.g. /bin/sh -c "..."). Replacing it with `shlex.split()` correctly handles quoted strings.